### PR TITLE
Quick pull request to remove unnecessary slashes from os.path.join(BASE_DIR, 'static') in STATICFILES_DIRS setting in settings.py

### DIFF
--- a/adage/adage/settings.py
+++ b/adage/adage/settings.py
@@ -157,7 +157,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 # STATIC_ROOT = os.path.join(BASE_DIR, '/static/')
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, '/static/'),
+    os.path.join(BASE_DIR, 'static'),
 )
 
 # Logging configuration (based on the "LOGGING" section of tribe/settings.py).


### PR DESCRIPTION
@dongbohu 