### PR TITLE
Customize eslint rules based on google coding style, and integrate es…

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,6 +11,8 @@ engines:
         javascript:
   eslint:
     enabled: true
+    config:
+      config: interface/eslint.conf.js
     channel: "eslint-3"
     exclude_paths:
     - "interface/Gruntfile.js"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,7 @@ engines:
     channel: "eslint-3"
     exclude_paths:
     - "interface/Gruntfile.js"
+    - "interface/eslint.google.js"
   fixme:
     enabled: false
   radon:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,0 @@
-extends: google
-
-ecmaFeatures:
-  modules: true
-
-globals:
-  angular: true

--- a/interface/Gruntfile.js
+++ b/interface/Gruntfile.js
@@ -20,6 +20,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-html2js');
   grunt.loadNpmTasks('grunt-protractor-runner');
   grunt.loadNpmTasks('grunt-protractor-webdriver');
+  grunt.loadNpmTasks('grunt-eslint');
 
   /**
    * Load in our build configuration file.
@@ -323,6 +324,18 @@ module.exports = function ( grunt ) {
           src: [ '<%= app_files.coffeeunit %>' ]
         }
       }
+    },
+
+    /**
+     * eslint configuration.
+     */
+    eslint: {
+      options: {
+        configFile: 'eslint.conf.js'
+      },
+      src: ['<%= app_files.js %>'],
+      unit: ['<%= app_files.jsunit %>'],
+      e2e: ['<%= app_files.jse2e %>']
     },
 
     /**

--- a/interface/build.config.js
+++ b/interface/build.config.js
@@ -23,6 +23,7 @@ module.exports = {
     js: [ 'src/**/*.js', '!src/**/*.spec.js', '!src/assets/**/*.js',
           '!src/test_e2e/**/*.js', '!src/**/*.e2e.js' ],
     jsunit: [ 'src/**/*.spec.js' ],
+    jse2e: [ 'src/test_e2e/**/*.js', 'src/**/*.e2e.js' ],
 
     coffee: [ 'src/**/*.coffee', '!src/**/*.spec.coffee' ],
     coffeeunit: [ 'src/**/*.spec.coffee' ],

--- a/interface/eslint.conf.js
+++ b/interface/eslint.conf.js
@@ -1,6 +1,6 @@
 /**
  * GreeneLab JavaScript ESLint rules, extends from Google coding guide at:
- * https://github.com/google/eslint-config-google/index.js (commit 40e3b15)
+ * https://github.com/google/eslint-config-google/index.js (commit 0037169)
  * (renamed to "eslint.google.js").
  */
 

--- a/interface/eslint.conf.js
+++ b/interface/eslint.conf.js
@@ -1,0 +1,31 @@
+/**
+ * GreeneLab JavaScript ESLint rules, extends from Google coding guide at:
+ * https://github.com/google/eslint-config-google/index.js (commit 40e3b15)
+ * (renamed to "eslint.google.js").
+ */
+
+module.exports = {
+  extends: './eslint.google.js',
+
+  globals: {
+    angular: true,
+    d3: true
+  },
+
+  // Customized rules.
+  // Possible values of Rule ID are:
+  //   0: 'off'; 1: 'warn'; 2: 'error'
+  // More details at:
+  //   http://eslint.org/docs/user-guide/configuring#configuring-rules
+  // gNNN: Line number of the same option in ./eslint.google.js
+  rules: {
+    'curly': 2,                   // (g081) Always use curly braces.
+    'comma-dangle': [2, 'never'], // (g185) Never allows trailing comma.
+    'indent': [2, 2],             // (g197) Indentation: always 2 spaces.
+    'keyword-spacing': 2,         // (g201) Whitepace before and after keyword.
+    'one-var': [2, {              // (g248) Allows "var x, y;".
+      var: 'always'
+    }],
+    'no-var': 0                   // (g300) Allows "var" declaration.
+  }
+};

--- a/interface/eslint.conf.js
+++ b/interface/eslint.conf.js
@@ -19,9 +19,9 @@ module.exports = {
   //   http://eslint.org/docs/user-guide/configuring#configuring-rules
   // gNNN: Line number of the same option in ./eslint.google.js
   rules: {
-    'curly': 2,                   // (g081) Always use curly braces.
-    'eqeqeq': [2, 'always'],      // (g086) Never allows '==' or '!=' operators.
-    'comma-dangle': [2, 'never'], // (g185) Never allows trailing comma.
+    'curly': 2,                   // (g080) Always use curly braces.
+    'eqeqeq': [2, 'always'],      // (g085) Never allows '==' or '!=' operators.
+    'comma-dangle': [2, 'never'], // (g184) Never allows trailing comma.
     'indent': [2, 2],             // (g197) Indentation: always 2 spaces.
     'keyword-spacing': 2,         // (g201) Space before and after keyword.
     'one-var': 0,                 // (g248) Allows "var x, y;".

--- a/interface/eslint.conf.js
+++ b/interface/eslint.conf.js
@@ -20,12 +20,11 @@ module.exports = {
   // gNNN: Line number of the same option in ./eslint.google.js
   rules: {
     'curly': 2,                   // (g081) Always use curly braces.
+    'eqeqeq': [2, 'always'],      // (g086) Never allows '==' or '!=' operators.
     'comma-dangle': [2, 'never'], // (g185) Never allows trailing comma.
     'indent': [2, 2],             // (g197) Indentation: always 2 spaces.
-    'keyword-spacing': 2,         // (g201) Whitepace before and after keyword.
-    'one-var': [2, {              // (g248) Allows "var x, y;".
-      var: 'always'
-    }],
+    'keyword-spacing': 2,         // (g201) Space before and after keyword.
+    'one-var': 0,                 // (g248) Allows "var x, y;".
     'no-var': 0                   // (g300) Allows "var" declaration.
   }
 };

--- a/interface/eslint.google.js
+++ b/interface/eslint.google.js
@@ -1,0 +1,316 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = {
+  rules: {
+    // The rules below are listed in the order they appear on the eslint
+    // rules page. All rules are listed to make it easier to keep in sync
+    // as new ESLint rules are added.
+    // http://eslint.org/docs/rules/
+    // - Rules in the `eslint:recommended` ruleset that aren't specifically
+    //   mentioned by the google styleguide are listed but commented out (so
+    //   they don't override a base ruleset).
+    // - Rules that are recommended but contradict the Google styleguide
+    //   are explicitely set to the Google styleguide value.
+
+    // Possible Errors
+    // http://eslint.org/docs/rules/#possible-errors
+    // ---------------------------------------------
+    'no-cond-assign': 0, // eslint:recommended
+    // 'no-console': 2, // eslint:recommended
+    // 'no-condition': 2, // eslint:recommended
+    // 'no-constant-condition': 2, // eslint:recommended
+    // 'no-control-regex': 2, // eslint:recommended
+    // 'no-debugger': 2, // eslint:recommended
+    // 'no-dupe-args': 2, // eslint:recommended
+    // 'no-dupe-keys': 2, // eslint:recommended
+    // 'no-duplicate-case': 2, // eslint:recommended
+    // 'no-empty-character-class': 2, // eslint:recommended
+    // 'no-empty': 2, // eslint:recommended
+    // 'no-ex-assign': 2, // eslint:recommended
+    // 'no-extra-boolean-cast': 2, // eslint:recommended
+    // 'no-extra-parens': 0,
+    // 'no-extra-semi': 2, // eslint:recommended
+    // 'no-func-assign': 2, // eslint:recommended
+    // 'no-inner-declarations': 2, // eslint:recommended
+    // 'no-invalid-regexp': 2, // eslint:recommended
+    'no-irregular-whitespace': 2, // eslint:recommended
+    // 'no-obj-calls': 2, // eslint:recommended
+    // 'no-prototype-builtins': 0,
+    // 'no-regex-spaces': 2, // eslint:recommended
+    // 'no-sparse-arrays': 2, // eslint:recommended
+    // 'no-template-curly-in-string': 0,
+    'no-unexpected-multiline': 2, // eslint:recommended
+    // 'no-unreachable': 2, // eslint:recommended
+    // 'no-unsafe-finally': 2, // eslint:recommended
+    // 'no-unsafe-negation': 0,
+    // 'use-isnan': 2 // eslint:recommended
+    'valid-jsdoc': [2, {
+      requireParamDescription: false,
+      requireReturn: false,
+      prefer: {returns: 'return'},
+    }],
+    // 'valid-typeof': 2 // eslint:recommended
+
+
+    // Best Practices
+    // http://eslint.org/docs/rules/#best-practices
+    // --------------------------------------------
+
+    // 'accessor-pairs': 0,
+    // 'array-callback-return': 0,
+    // 'block-scoped-var': 0,
+    // 'class-methods-use-this': 0,
+    // 'complexity': 0,
+    // 'consistent-return': 0
+    // 'curly': 0, // TODO(philipwalton): add an option to enforce braces with
+                   // the exception of simple, single-line if statements.
+    // 'default-case': 0,
+    // 'dot-location': 0,
+    // 'dot-notation': 0,
+    // 'eqeqeq': 0,
+    'guard-for-in': 2,
+    // 'no-alert': 0,
+    'no-caller': 2,
+    // 'no-case-declarations': 2, // eslint:recommended
+    // 'no-div-regex': 0,
+    // 'no-else-return': 0,
+    // 'no-empty-function': 0,
+    // 'no-empty-pattern': 2, // eslint:recommended
+    // 'no-eq-null': 0,
+    // 'no-eval': 0,
+    'no-extend-native': 2,
+    'no-extra-bind': 2,
+    // 'no-extra-label': 0,
+    // 'no-fallthrough': 2, // eslint:recommended
+    // 'no-floating-decimal': 0,
+    // 'no-global-assign': 0,
+    // 'no-implicit-coercion': 0,
+    // 'no-implicit-globals': 0,
+    // 'no-implied-eval': 0,
+    'no-invalid-this': 2,
+    // 'no-iterator': 0,
+    // 'no-labels': 0,
+    // 'no-lone-blocks': 0,
+    // 'no-loop-func': 0,
+    // 'no-magic-numbers': 0,
+    'no-multi-spaces': 2,
+    'no-multi-str': 2,
+    // 'no-new-func': 0,
+    'no-new-wrappers': 2,
+    // 'no-new': 0,
+    // 'no-octal-escape': 0,
+    // 'no-octal': 2, // eslint:recommended
+    // 'no-param-reassign': 0,
+    // 'no-proto': 0,
+    // 'no-redeclare': 2, // eslint:recommended
+    // 'no-return-assign': 0,
+    // 'no-script-url': 0,
+    // 'no-self-assign': 2, // eslint:recommended
+    // 'no-self-compare': 0,
+    // 'no-sequences': 0,
+    'no-throw-literal': 2, // eslint:recommended
+    // 'no-unmodified-loop-condition': 0,
+    // 'no-unused-expressions': 0,
+    // 'no-unused-labels': 2, // eslint:recommended
+    // 'no-useless-call': 0,
+    // 'no-useless-concat': 0,
+    // 'no-useless-escape': 0,
+    // 'no-void': 0,
+    // 'no-warning-comments': 0,
+    'no-with': 2,
+    // 'radix': 0,
+    // 'vars-on-top': 0,
+    // 'wrap-iife': 0,
+    // 'yoda': 0,
+
+    // Strict Mode
+    // http://eslint.org/docs/rules/#strict-mode
+    // -----------------------------------------
+    // 'script': 0,
+
+    // Variables
+    // http://eslint.org/docs/rules/#variables
+    // ---------------------------------------
+    // 'init-declarations': 0,
+    // 'no-catch-shadow': 0,
+    // 'no-delete-var': 2, // eslint:recommended
+    // 'no-label-var': 0,
+    // 'no-restricted-globals': 0,
+    // 'no-shadow-restricted-names': 0,
+    // 'no-shadow': 0,
+    // 'no-undef-init': 0,
+    // 'no-undef': 2, // eslint:recommended
+    // 'no-undefined': 0,
+    'no-unused-vars': [2, {args: 'none'}], // eslint:recommended
+    // 'no-use-before-define': 0,
+
+    // Node.js and CommonJS
+    // http://eslint.org/docs/rules/#nodejs-and-commonjs
+    // -------------------------------------------------
+    // 'callback-return': 0,
+    // 'global-require': 0,
+    // 'handle-callback-err': 0,
+    // 'no-mixed-requires': 0,
+    // 'no-new-require': 0,
+    // 'no-path-concat': 0,
+    // 'no-process-env': 0,
+    // 'no-process-exit': 0,
+    // 'no-restricted-modules': 0,
+    // 'no-restricted-properties': 0,
+    // 'no-sync': 0,
+
+    // Stylistic Issues
+    // http://eslint.org/docs/rules/#stylistic-issues
+    // ----------------------------------------------
+    'array-bracket-spacing': [2, 'never'],
+    // 'block-spacing': 0,
+    'brace-style': 2,
+    'camelcase': 2,
+    'comma-dangle': [2, 'always-multiline'],
+    'comma-spacing': 2,
+    'comma-style': 2,
+    'computed-property-spacing': 2,
+    // 'consistent-this': 0,
+    'eol-last': 2,
+    'func-call-spacing': 2,
+    // 'func-names': 0,
+    // 'func-style': 0,
+    // 'id-blacklist': 0,
+    // 'id-length': 0,
+    // 'id-match': 0,
+    // 'indent': 0, // TODO(philipwalton): this rule isn't compatible with
+                    // Google's 4-space indent for line continuations.
+    // 'jsx-quotes': 0,
+    'key-spacing': 2,
+    'keyword-spacing': 0,
+    // 'line-comment-position': 0,
+    'linebreak-style': 2,
+    // 'lines-around-comment': 0,
+    // 'lines-around-directive': 0,
+    // 'max-depth': 0,
+    'max-len': [2, {
+      code: 80,
+      tabWidth: 2,
+      ignoreUrls: true,
+      ignorePattern: '^goog\.(module|require)',
+    }],
+    // 'max-lines': 0,
+    // 'max-nested-callbacks': 0,
+    // 'max-params': 0,
+    // 'max-statements-per-line': 0,
+    // 'max-statements': 0,
+    // 'multiline-ternary': 0, // TODO(philipwalton): add a rule to enfore the
+                               // operator appearing at the end of the line.
+    'new-cap': 2,
+    // 'new-parens': 0,
+    // 'newline-after-var': 0,
+    // 'newline-before-return': 0,
+    // 'newline-per-chained-call': 0,
+    'no-array-constructor': 2,
+    // 'no-bitwise': 0,
+    // 'no-continue': 0,
+    // 'no-inline-comments': 0,
+    // 'no-lonely-if': 0,
+    // 'no-mixed-operators': 0,
+    'no-mixed-spaces-and-tabs': 2, // eslint:recommended
+    'no-multiple-empty-lines': [2, {max: 2}],
+    // 'no-negated-condition': 0,
+    // 'no-nested-ternary': 0,
+    'no-new-object': 2,
+    // 'no-plusplus': 0,
+    // 'no-restricted-syntax': 0,
+    // 'no-tabs': 0,
+    // 'no-ternary': 0,
+    'no-trailing-spaces': 2,
+    // 'no-underscore-dangle': 0,
+    // 'no-unneeded-ternary': 0,
+    // 'no-whitespace-before-property': 0,
+    // 'object-curly-newline': 0,
+    'object-curly-spacing': 2,
+    // 'object-property-newline': 0,
+    // 'one-var-declaration-per-line': 0,
+    'one-var': [2, {
+      var: 'never',
+      let: 'never',
+      const: 'never',
+    }],
+    // 'operator-assignment': 0,
+    // 'operator-linebreak': 0,
+    'padded-blocks': [2, 'never'],
+    'quote-props': [2, 'consistent'],
+    'quotes': [2, 'single', {allowTemplateLiterals: true}],
+    'require-jsdoc': [2, {
+      require: {
+        FunctionDeclaration: true,
+        MethodDefinition: true,
+        ClassDeclaration: true,
+      },
+    }],
+    'semi-spacing': 2,
+    'semi': 2,
+    // 'sort-keys': 0,
+    // 'sort-vars': 0,
+    'space-before-blocks': 2,
+    'space-before-function-paren': [2, 'never'],
+    // 'space-in-parens': 0,
+    // 'space-infix-ops': 0,
+    // 'space-unary-ops': 0,
+    'spaced-comment': [2, 'always'],
+    // 'unicode-bom': 0,
+    // 'wrap-regex': 0,
+
+    // ECMAScript 6
+    // http://eslint.org/docs/rules/#ecmascript-6
+    // ------------------------------------------
+    // 'arrow-body-style': 0,
+    'arrow-parens': [2, 'always'], // TODO(philipwalton): technically arrow
+                                   // parens are optional but recommended.
+                                   // ESLint doesn't support a *consistent*
+                                   // setting so "always" is used.
+    // 'arrow-spacing': 0,
+    'constructor-super': 2, // eslint:recommended
+    'generator-star-spacing': [2, 'after'],
+    // 'no-class-assign': 0,
+    // 'no-confusing-arrow': 0,
+    // 'no-const-assign': 0, // eslint:recommended
+    // 'no-dupe-class-members': 0, // eslint:recommended
+    // 'no-duplicate-imports': 0,
+    'no-new-symbol': 2, // eslint:recommended
+    // 'no-restricted-imports': 0,
+    'no-this-before-super': 2,  // eslint:recommended
+    // 'no-useless-computed-key': 0,
+    // 'no-useless-constructor': 0,
+    // 'no-useless-rename': 0,
+    'no-var': 2,
+    // 'object-shorthand': 0,
+    // 'prefer-arrow-callback': 0,
+    // 'prefer-const': 0,
+    // 'prefer-numeric-literals': 0,
+    // 'prefer-reflect': 0,
+    'prefer-rest-params': 2,
+    'prefer-spread': 2,
+    // 'prefer-template': 0,
+    // 'require-yield': 2, // eslint:recommended
+    'rest-spread-spacing': 2,
+    // 'sort-imports': 0,
+    // 'symbol-description': 0,
+    // 'template-curly-spacing': 0,
+    'yield-star-spacing': [2, 'after'],
+  },
+};

--- a/interface/eslint.google.js
+++ b/interface/eslint.google.js
@@ -33,7 +33,6 @@ module.exports = {
     // ---------------------------------------------
     'no-cond-assign': 0, // eslint:recommended
     // 'no-console': 2, // eslint:recommended
-    // 'no-condition': 2, // eslint:recommended
     // 'no-constant-condition': 2, // eslint:recommended
     // 'no-control-regex': 2, // eslint:recommended
     // 'no-debugger': 2, // eslint:recommended
@@ -189,6 +188,7 @@ module.exports = {
     // 'consistent-this': 0,
     'eol-last': 2,
     'func-call-spacing': 2,
+    // 'func-name-matching': 0,
     // 'func-names': 0,
     // 'func-style': 0,
     // 'id-blacklist': 0,
@@ -215,7 +215,7 @@ module.exports = {
     // 'max-params': 0,
     // 'max-statements-per-line': 0,
     // 'max-statements': 0,
-    // 'multiline-ternary': 0, // TODO(philipwalton): add a rule to enfore the
+    // 'multiline-ternary': 0, // TODO(philipwalton): add a rule to enforce the
                                // operator appearing at the end of the line.
     'new-cap': 2,
     // 'new-parens': 0,

--- a/interface/package.json
+++ b/interface/package.json
@@ -16,8 +16,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": "^3.7.1",
-    "eslint-config-google": "^0.6.0",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-coffeelint": "^0.0.16",
@@ -30,6 +28,7 @@
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-conventional-changelog": "^6.1.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-html2js": "^0.3.6",
     "grunt-karma": "^2.0.0",
     "grunt-ng-annotate": "^2.0.2",

--- a/interface/src/README.md
+++ b/interface/src/README.md
@@ -23,7 +23,7 @@ src/
 
 - `src/app/` - application-specific code, i.e. code not likely to be reused in
   another application. [Read more &raquo;](app/README.md)
-- `src/assets/` - static files like fonts and images. 
+- `src/assets/` - static files like fonts and images.
   [Read more &raquo;](assets/README.md)
 - `src/common/` - third-party libraries or components likely to be reused in
   another application. [Read more &raquo;](common/README.md)
@@ -38,7 +38,7 @@ See each directory for a detailed explanation.
 The `index.html` file is the HTML document of the single-page application (SPA)
 that should contain all markup that applies to everything in the app, such as
 the header and footer. It declares with `ngApp` that this is `ngBoilerplate`,
-specifies the main `AppCtrl` controller, and contains the `ngView` directive
+specifies the main `AppCtrl` controller, and contains the `ui-view` directive
 into which route templates are placed.
 
 Unlike any other HTML document (e.g. the templates), `index.html` is compiled as

--- a/interface/src/app/README.md
+++ b/interface/src/app/README.md
@@ -29,7 +29,7 @@ glimpse of how powerful this simple construct can be.
 ## `app.js`
 
 This is our main app configuration file. It kickstarts the whole process by
-requiring all the modules from `src/app` that we need. We must load these now to
+requiring all the modules from `src/app/` that we need. We must load these now to
 ensure the routes are loaded. If as in our "products" example there are
 subroutes, we only require the top-level module, and allow the submodules to
 require their own submodules.
@@ -46,9 +46,8 @@ angular.module( 'ngBoilerplate', [
   'templates-app',
   'templates-common',
   'ngBoilerplate.home',
-  'ngBoilerplate.about'
-  'ui.router',
-  'ui.route'
+  'ngBoilerplate.about',
+  'ui.router'
 ])
 ```
 


### PR DESCRIPTION
This PR includes:
* **eslint.google.js** (new file): a clone of Google's eslint rules at **eslint-config-google**. You do **NOT** need to review this file.
* **eslint.conf.js** (new file): includes a few coding style rules of our own. I added some comments in this file to explain what they mean. For more details, please check: http://eslint.org/docs/rules/
* **Gruntfile.js**: modified to integrate eslint into Grunt. Note that since most of the js files in our codebase don't conform to the rules yet, I didn't include **eslint** task into the default **grunt** command. So typing **grunt** won't run **eslint**. You have to type **grunt eslint** to launch it. (Once we clean up our codebase, I will add `eslint` task into `build` so that `grunt` command will launch it automatically.
* **package.json**: Removed **eslint** and **eslint-config-google** dependencies, added `grunt-eslint`.
* **build.config.js**: defined a variable for e2e test files.
* A few corrections of typos in **src/README.md** and **src/app/README.md**.  
* Since we are using grunt to take care of eslint, I removed **.eslintrc.yaml**.