### PR TITLE
Add .eslintignore to ignore some js files

### DIFF
--- a/interface/.eslintignore
+++ b/interface/.eslintignore
@@ -1,0 +1,7 @@
+build.config.js
+eslint.google.js
+Gruntfile.js
+build/*
+karma/*
+node_modules/*
+vendor/*

--- a/interface/.eslintignore
+++ b/interface/.eslintignore
@@ -1,6 +1,7 @@
 build.config.js
 eslint.google.js
 Gruntfile.js
+bin/*
 build/*
 karma/*
 node_modules/*


### PR DESCRIPTION
I created a **.eslintignore** file, which is used to ignore some JavaScript files when you run `eslint` from command line or when your IDE runs it on the background. The ignored files either belong to other packages (such as ngbp) or are generated by `grunt` compilation.