### PR TITLE
Cache activity data

### DIFF
--- a/interface/src/app/analyze/analysis/analysis.js
+++ b/interface/src/app/analyze/analysis/analysis.js
@@ -16,7 +16,8 @@ angular.module('adage.analyze.analysis', [
 
 .controller('AnalysisCtrl', ['$scope', '$log', '$location', 'Sample',
 'Activity', 'AnnotationType', 'SampleBin',
-function AnalysisCtrl($scope, $log, $location, Sample, Activity, AnnotationType, SampleBin) {
+function AnalysisCtrl($scope, $log, $location, Sample, Activity,
+AnnotationType, SampleBin) {
   // give our templates a way to access the SampleBin service
   $scope.sb = SampleBin;
 
@@ -132,7 +133,8 @@ function AnalysisCtrl($scope, $log, $location, Sample, Activity, AnnotationType,
         // "properties": {
         //   "labels": {
         //     // "text": {"field": "sample_object.ml_data_source"}
-        //     "text": {"template": "test {{datum.data.sample_object.ml_data_source}}"}
+        //     "text": {"template": "test
+        // {{datum.data.sample_object.ml_data_source}}"}
         //   }
         // }
       }
@@ -185,23 +187,7 @@ function AnalysisCtrl($scope, $log, $location, Sample, Activity, AnnotationType,
     SampleBin.getSampleDetails(SampleBin.samples[i]);
   }
 
-  SampleBin.getActivityForSampleList($scope.analysis,
-    // success callback
-    function(responseObject, responseHeaders) {
-      if (responseObject) {
-        $scope.analysis.queryStatus = '';
-        // FIXME retrieved data belong in a cache inside sampleBin service
-        SampleBin.heatmapData.activity = responseObject.objects;
-        // TODO need to find & report (list) samples that return no results
-      }
-    },
-    // failure callback
-    function(responseObject, responseHeaders) {
-      $log.error('Query errored with: ' + responseObject);
-      // TODO need a unit test to prove this works
-      $scope.analysis.queryStatus = 'Query for activity failed.';
-    }
-  );
+  SampleBin.getActivityForSampleList($scope.analysis);
 }])
 
 .directive('analysisDetail', function() {

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -20,7 +20,7 @@
     <tr ng-repeat="id in sb.samples" as-sortable-item>
       <td>
         <button type="button" class="btn close"
-        ng-click="sb.remove_sample(id)" aria-label="Delete">
+        ng-click="sb.removeSample(id)" aria-label="Delete">
           <i class="fa fa-times" aria-hidden="true"></i>
         </button>
       </td>

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -27,13 +27,21 @@ function($log, Sample, Activity) {
             ' already in the sample list; ignoring.');
       } else {
         SampleBin.samples.push(+id);
+        // TODO need to report query progress and errors somehow
+        // TODO this should use caching and promises to fetch sample data
+        // 1. check cache for existing Sample data. Hit = return
+        // 2. if cache miss: 
+        // 2a. getSampleDetails & append a promise to SampleBin.promises
+        // 2b. getActivityForSample & append a promise to SampleBin.promises
+        // ... now can use Promise.all(SampleBin.promises).then() to trigger
+        // a redraw of the heatmap when ready
       }
     },
 
     remove_sample: function(id) {
       var pos = SampleBin.samples.indexOf(+id);
       SampleBin.samples.splice(pos, 1);
-      // TODO need to report query progress and errors somehow
+      // TODO now need to mutate SampleBin.heatmapData.activity rather than re-retrieve data
       Activity.get({sample__in: SampleBin.samples.join()},
         // success callback
         function(responseObject, responseHeaders) {

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -13,12 +13,14 @@ angular.module('adage.analyze.sampleBin', [
   return $resource('/api/v0/activity/');
 }])
 
-.factory('SampleBin', ['$log', 'Sample', 'Activity',
-function($log, Sample, Activity) {
+.factory('SampleBin', ['$log', '$cacheFactory', 'Sample', 'Activity',
+function($log, $cacheFactory, Sample, Activity) {
   var SampleBin = {
     samples: [],
     heatmapData: {},
     sampleData: {},
+    sampleCache: $cacheFactory('sample'),
+    activityCache: $cacheFactory('activity'),
 
     add_sample: function(id) {
       if (SampleBin.samples.indexOf(+id) !== -1) {
@@ -30,7 +32,7 @@ function($log, Sample, Activity) {
         // TODO need to report query progress and errors somehow
         // TODO this should use caching and promises to fetch sample data
         // 1. check cache for existing Sample data. Hit = return
-        // 2. if cache miss: 
+        // 2. if cache miss:
         // 2a. getSampleDetails & append a promise to SampleBin.promises
         // 2b. getActivityForSample & append a promise to SampleBin.promises
         // ... now can use Promise.all(SampleBin.promises).then() to trigger

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -22,10 +22,10 @@ function($log, $cacheFactory, Sample, Activity) {
     sampleCache: $cacheFactory('sample'),
     activityCache: $cacheFactory('activity'),
 
-    add_sample: function(id) {
+    addSample: function(id) {
       if (SampleBin.samples.indexOf(+id) !== -1) {
         // quietly ignore the double-add
-        $log.warn('SampleBin.add_sample: ' + id +
+        $log.warn('SampleBin.addSample: ' + id +
             ' already in the sample list; ignoring.');
       } else {
         SampleBin.samples.push(+id);
@@ -40,11 +40,12 @@ function($log, $cacheFactory, Sample, Activity) {
       }
     },
 
-    remove_sample: function(id) {
+    removeSample: function(id) {
       var pos = SampleBin.samples.indexOf(+id);
       SampleBin.samples.splice(pos, 1);
-      // TODO now need to mutate SampleBin.heatmapData.activity rather than re-retrieve data
-      Activity.get({sample__in: SampleBin.samples.join()},
+      // TODO caching: here need to update SampleBin.heatmapData.activity
+      // rather than re-retrieve data
+      Activity.get({'sample__in': SampleBin.samples.join()},
         // success callback
         function(responseObject, responseHeaders) {
           if (responseObject) {
@@ -59,32 +60,32 @@ function($log, $cacheFactory, Sample, Activity) {
       );
     },
 
-    add_experiment: function(sample_id_list) {
-      for (var i = 0; i < sample_id_list.length; i++) {
-        SampleBin.add_sample(sample_id_list[i]);
+    addExperiment: function(sampleIdList) {
+      for (var i = 0; i < sampleIdList.length; i++) {
+        SampleBin.addSample(sampleIdList[i]);
       }
     },
 
-    add_item: function(search_item) {
-      if (search_item.item_type === 'sample') {
-        SampleBin.add_sample(search_item.pk);
-      } else if (search_item.item_type === 'experiment') {
-        SampleBin.add_experiment(search_item.related_items);
+    addItem: function(searchItem) {
+      if (searchItem.item_type === 'sample') {
+        SampleBin.addSample(searchItem.pk);
+      } else if (searchItem.item_type === 'experiment') {
+        SampleBin.addExperiment(searchItem.related_items);
       }
     },
 
-    has_item: function(search_item) {
-      if (search_item.item_type === 'sample') {
-        if (SampleBin.samples.indexOf(+search_item.pk) !== -1) {
+    hasItem: function(searchItem) {
+      if (searchItem.item_type === 'sample') {
+        if (SampleBin.samples.indexOf(+searchItem.pk) !== -1) {
           return true;
         } else {
           return false;
         }
-      } else if (search_item.item_type === 'experiment') {
+      } else if (searchItem.item_type === 'experiment') {
         // what we want to know, in the case of an experiment, is 'are
         // all of the samples from this experiment already added?'
-        for (var i = 0; i < search_item.related_items.length; i++) {
-          if (SampleBin.samples.indexOf(+search_item.related_items[i]) === -1) {
+        for (var i = 0; i < searchItem.related_items.length; i++) {
+          if (SampleBin.samples.indexOf(+searchItem.related_items[i]) === -1) {
             return false;
           }
         }
@@ -129,7 +130,7 @@ function($log, $cacheFactory, Sample, Activity) {
     getActivityForSampleList: function(respObj, successFn, failFn) {
       // retrieve activity data for heatmap to display
       respObj.queryStatus = 'Retrieving sample activity...';
-      Activity.get({sample__in: this.samples.join()}, successFn, failFn);
+      Activity.get({'sample__in': this.samples.join()}, successFn, failFn);
     }
   };
 
@@ -143,7 +144,7 @@ function SampleBinCtrl($scope, $log, $uibModal, Sample, SampleBin) {
   $scope.sb = SampleBin;
 
   $scope.show = function() {
-    var modalInstance = $uibModal.open({
+    $uibModal.open({
       animation: true,
       templateUrl: 'analyze/analysis/analysisModal.tpl.html',
       controller: 'AnalysisModalCtrl',

--- a/interface/src/app/analyze/analyze.tpl.html
+++ b/interface/src/app/analyze/analyze.tpl.html
@@ -23,8 +23,8 @@
             </div>
             <div class="media-body">
               <button type="button" class="btn"
-              ng-class="sb.has_item(search_item)?'disabled':''"
-              ng-click="sb.add_item(search_item)">
+              ng-class="sb.hasItem(search_item)?'disabled':''"
+              ng-click="sb.addItem(search_item)">
                 <i class="fa fa-plus" aria-hidden="true"></i>
               </button>
               <h4 class="list-group-item-heading">


### PR DESCRIPTION
Initial caching implementation for activity data (see `sampleBin.rebuildHeatmapActivity()`), camelCase and other ESLint compliance.

We need a similar caching ability for Sample metadata, but that will be handled in a separate pull request once this request is reviewed and any feedback incorporated.