### PR TITLE
Changes on the backend for the new Node page

### DIFF
--- a/adage/adage/urls.py
+++ b/adage/adage/urls.py
@@ -19,9 +19,10 @@ from django.contrib import admin
 from tastypie.api import Api
 from organisms.api import OrganismResource
 from genes.api import GeneResource
-from analyze.api import SearchResource, ExperimentResource,\
-    AnnotationTypeResource, SampleResource, NodeResource, ActivityResource,\
-    EdgeResource, ParticipationResource
+from analyze.api import (SearchResource, ExperimentResource,
+                         AnnotationTypeResource, SampleResource,
+                         MLModelResource, NodeResource, ActivityResource,
+                         EdgeResource, ParticipationResource)
 
 v0_api = Api(api_name='v0')
 v0_api.register(SearchResource())
@@ -30,6 +31,7 @@ v0_api.register(AnnotationTypeResource())
 v0_api.register(SampleResource())
 v0_api.register(OrganismResource())
 v0_api.register(GeneResource())
+v0_api.register(MLModelResource())
 v0_api.register(NodeResource())
 v0_api.register(ActivityResource())
 v0_api.register(EdgeResource())

--- a/adage/analyze/api.py
+++ b/adage/analyze/api.py
@@ -349,6 +349,12 @@ class EdgeResource(ModelResource):
 
 
 class ParticipationResource(ModelResource):
+    """
+    To avoid unnecessary table joins and improve the query performance, only
+    "gene" is enabled as a foreign key (because the Node page on frontend needs
+    the gene details given a certain node), but at this time, we don't intend
+    to do a query that returns node details given an input gene.
+    """
     node = fields.IntegerField(attribute='node_id', null=False)
     gene = fields.ForeignKey(GeneResource, "gene", full=True)
 

--- a/adage/analyze/api.py
+++ b/adage/analyze/api.py
@@ -352,8 +352,8 @@ class ParticipationResource(ModelResource):
     """
     To avoid unnecessary table joins and improve the query performance, only
     "gene" is enabled as a foreign key (because the Node page on frontend needs
-    the gene details given a certain node), but at this time, we don't intend
-    to do a query that returns node details given an input gene.
+    the gene details given a certain node).  At this time, we don't intend to
+    do a query that returns node details given an input gene.
     """
     node = fields.IntegerField(attribute='node_id', null=False)
     gene = fields.ForeignKey(GeneResource, "gene", full=True)

--- a/adage/analyze/api.py
+++ b/adage/analyze/api.py
@@ -11,8 +11,8 @@ from tastypie.exceptions import BadRequest
 from haystack.query import SearchQuerySet
 from haystack.inputs import AutoQuery
 from models import (
-    Experiment, Sample, SampleAnnotation, AnnotationType, Node, Activity, Edge,
-    Participation
+    Experiment, Sample, SampleAnnotation, AnnotationType, MLModel, Node,
+    Activity, Edge, Participation
 )
 
 # Many helpful hints for this implementation came from:
@@ -208,7 +208,15 @@ class SampleResource(ModelResource):
         return response
 
 
+class MLModelResource(ModelResource):
+    class Meta:
+        queryset = MLModel.objects.all()
+        allowed_methods = ['get']
+
+
 class NodeResource(ModelResource):
+    mlmodel = fields.ForeignKey(MLModelResource, "mlmodel", full=True)
+
     class Meta:
         queryset = Node.objects.all()
         resource_name = 'node'
@@ -342,7 +350,7 @@ class EdgeResource(ModelResource):
 
 class ParticipationResource(ModelResource):
     node = fields.IntegerField(attribute='node_id', null=False)
-    gene = fields.IntegerField(attribute='gene_id', null=False)
+    gene = fields.ForeignKey(GeneResource, "gene", full=True)
 
     class Meta:
         queryset = Participation.objects.all()

--- a/adage/analyze/api.py
+++ b/adage/analyze/api.py
@@ -352,8 +352,9 @@ class ParticipationResource(ModelResource):
     """
     To avoid unnecessary table joins and improve the query performance, only
     "gene" is enabled as a foreign key (because the Node page on frontend needs
-    the gene details given a certain node).  At this time, we don't intend to
-    do a query that returns node details given an input gene.
+    the gene details given a certain node); "node" is not set as a foreign key
+    because at this time, we don't intend to do a query that returns node
+    details given an input gene.
     """
     node = fields.IntegerField(attribute='node_id', null=False)
     gene = fields.ForeignKey(GeneResource, "gene", full=True)


### PR DESCRIPTION
This PR includes the following changes:

1. api.py: Set `full` flag to true on `gene` attribute of **ParticipationResource** class; Add a new **MLModelResource** class (based on `MLModel` in **model.py**). This change will allow the Node page to access the corresponding machine learning model's name, which will be shown on frontend.
 
2. url.py: Enable **MLModelResource**.
 