### PR TITLE
Tweak codeclimate and eslint rules and polish network.js

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,7 @@ engines:
         python:
           mass_threshold: 50
         javascript:
+          mass_threshold: 50
   eslint:
     enabled: true
     config:

--- a/interface/eslint.conf.js
+++ b/interface/eslint.conf.js
@@ -26,6 +26,7 @@ module.exports = {
     'keyword-spacing': 2,         // (g201) Space before and after keyword.
     'one-var': 0,                 // (g248) Allows "var x, y;".
     'space-in-parens': 2,         // (g271) No spaces after '(' or before ')'.
+    'space-infix-ops': 2,         // (g272) Space needed around infix operator.
     'no-var': 0                   // (g300) Allows "var" declaration.
   }
 };

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -4,12 +4,11 @@
 
 angular.module('adage.gene.network', [
   'ui.router',
-  'placeholders',
   'ui.bootstrap',
   'rzModule'
 ])
 
-.config(function config($stateProvider) {
+.config(['$stateProvider', function($stateProvider) {
   $stateProvider.state('gene_network', {
     url: '/gene_network/?genes&mlmodel',
     views: {
@@ -20,7 +19,7 @@ angular.module('adage.gene.network', [
     },
     data: {pageTitle: 'Gene Network'}
   });
-})
+}])
 
 .factory('EdgeService', ['$resource', function($resource) {
   return $resource('/api/v0/edge/');


### PR DESCRIPTION
This is a trivial PR. It includes:
(1) Set **mass threshold** for JavaScript programs in codeclimate; 
(2) Added a new eslint rule to enforce a space before and after infix operators; 
(3) Polished network.js (thanks to @mhuyck's comments on my PR of the node page).