### PR TITLE
Add Links on Gene-Gene Network to Node Page

### DIFF
--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -176,18 +176,18 @@ angular.module('adage.gene.network', [
          */
         function getGeneInfo(data) {
           var result = '<div id="title">' + data.label + '</div>';
-          result += '<br />Entrez ID: ' + data.entrezid;
+          result += '<br>Entrez ID: ' + data.entrezid;
           if (data.systematic_name) {
-            result += '<br />Systematic name: ' + data.systematic_name;
+            result += '<br>Systematic name: ' + data.systematic_name;
           }
           if (data.standard_name) {
-            result += '<br />Standard name: ' + data.standard_name;
+            result += '<br>Standard name: ' + data.standard_name;
           }
           if (data.description) {
-            result += '<br />Description: ' + data.description;
+            result += '<br>Description: ' + data.description;
           }
           if (data.aliases) {
-            result += '<br />aliases: ' + data.aliases;
+            result += '<br>aliases: ' + data.aliases;
           }
           return result;
         }
@@ -210,7 +210,8 @@ angular.module('adage.gene.network', [
         function showEdgeTip(data) {
           geneTip.hide(); // Hide gene-tip window (if any) first.
           var rawWeight = data.weight + rawMinWeight;
-          var htmlText = 'Edge weight: ' + rawWeight.toFixed(3);
+          var weightPrecision = 3;
+          var htmlText = 'Edge weight: ' + rawWeight.toFixed(weightPrecision);
           var heavyGenes = [data.gene1.id, data.gene2.id].join(',');
           var target = d3.event.target;
           NodeService.get(
@@ -218,11 +219,11 @@ angular.module('adage.gene.network', [
             function success(response) {
               var i = 0, n = response.objects.length;
               var anchorTag;
-              htmlText += '<br />' + n + (n > 1 ? ' nodes are ' : ' node is ');
+              htmlText += '<br>' + n + (n > 1 ? ' nodes are ' : ' node is ');
               htmlText += 'related to both genes' + (n > 0 ? ':' : '.');
               for (; i < n; ++i) {
                 anchorTag = '<a href="#/node/' + response.objects[i].id + '">';
-                htmlText += '<br />* ' + anchorTag + response.objects[i].name;
+                htmlText += '<br>* ' + anchorTag + response.objects[i].name;
                 htmlText += '</a>';
               }
               edgeTip.html(htmlText);
@@ -232,7 +233,7 @@ angular.module('adage.gene.network', [
               var message = 'Failed to get node info for gene edge: ' +
                   response.statusCode + ' ' + response.statusText;
               $log.error(message);
-              htmlText += '<br />' + message + '. Please try again later.';
+              htmlText += '<br>' + message + '. Please try again later.';
               edgeTip.html(htmlText);
               edgeTip.show(data, target);
             }

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -18,18 +18,22 @@ angular.module('adage.gene.network', [
         controller: 'GeneNetworkCtrl as ctrl'
       }
     },
-    // When "gene_network" state exits, remove "edge-tip" elements from the DOM.
-    // (Without this function, the edge tip window will be visible in other
-    // states too.) The "gene-tip" element will disappear when mouse is out,
-    // so we don't need to worry about it.
+    // When "gene_network" state exits, remove "gene-tip" and "edge-tip"
+    // elements from the DOM. (Without this function, the tips window will
+    // be visible in other states too.)
     onExit: function() {
-      var elements = document.getElementsByClassName('edge-tip');
-      if (elements) { // This should be always true.
-        var n = elements.length;
-        for (var i = 0; i < n; ++i) {
-          elements[i].parentNode.removeChild(elements[i]);
+      var removeTips = function(className) {
+        var elements = document.getElementsByClassName(className);
+        var i, n;
+        if (elements) { // This should be always true.
+          n = elements.length;
+          for (i = 0; i < n; ++i) {
+            elements[i].parentNode.removeChild(elements[i]);
+          }
         }
-      }
+      };
+      removeTips('gene-tip');
+      removeTips('edge-tip');
     },
     data: {pageTitle: 'Gene Network'}
   });
@@ -251,8 +255,7 @@ angular.module('adage.gene.network', [
           .call(edgeTip);
 
         geneTip.html(getGeneInfo);
-        network.onGene('mouseover.custom', geneTip.show);
-        network.onGene('mouseout.custom', geneTip.hide);
+        network.onGene('click.custom', geneTip.show);
         network.onEdge('click.custom', showEdgeTip);
 
         // Draw network svg with legend and filter.
@@ -260,14 +263,20 @@ angular.module('adage.gene.network', [
           .filter(0, self.maxNodeNum)
           .draw();
 
-        // Add event handler so that edge-tip will be hidden when clicked:
-        var edgeTips = document.getElementsByClassName('edge-tip');
-        if (edgeTips) {
-          var n = edgeTips.length;
-          for (var i = 0; i < n; ++i) {
-            edgeTips[i].onclick = hideEdgeTip;
+        // Add event handlers to gene-tip and edge-tip so that they will be
+        // hidden when clicked:
+        var addClickHandler = function(className, handler) {
+          var elements = document.getElementsByClassName(className);
+          var i, n;
+          if (elements) {
+            n = elements.length;
+            for (i = 0; i < n; ++i) {
+              elements[i].onclick = handler;
+            }
           }
-        }
+        };
+        addClickHandler('gene-tip', geneTip.hide);
+        addClickHandler('edge-tip', hideEdgeTip);
       } // End of drawNetwork()
 
       EdgeService.get(

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -193,57 +193,50 @@ angular.module('adage.gene.network', [
         }
 
         /**
-         * Callback function to show edge tips when mouse is over an edge.
+         * Callback function to show gene tips when a gene is clicked.
+         * @param {gene_data} data;
+         * @return {void}.
+         */
+        function showGeneTip(data) {
+          edgeTip.hide(); // Hide edge-tip window (if any) first.
+          geneTip.show(data);
+        }
+
+        /**
+         * Callback function to show edge tips when an edge is clicked.
          * @param {edge_data} data;
          * @return {void}.
          */
         function showEdgeTip(data) {
+          geneTip.hide(); // Hide gene-tip window (if any) first.
           var rawWeight = data.weight + rawMinWeight;
-          var str = 'Edge weight: ' + rawWeight.toFixed(3);
+          var htmlText = 'Edge weight: ' + rawWeight.toFixed(3);
           var heavyGenes = [data.gene1.id, data.gene2.id].join(',');
           var target = d3.event.target;
           NodeService.get(
             {'heavy_genes': heavyGenes, 'limit': 0},
             function success(response) {
               var i = 0, n = response.objects.length;
-              var uri;
-              str += '<br />' + n + (n > 1 ? ' nodes are ' : ' node is ');
-              str += 'related to both genes' + (n > 0 ? ':' : '.');
+              var anchorTag;
+              htmlText += '<br />' + n + (n > 1 ? ' nodes are ' : ' node is ');
+              htmlText += 'related to both genes' + (n > 0 ? ':' : '.');
               for (; i < n; ++i) {
-                uri = '<a href="#/node/' + response.objects[i].id + '">';
-                str += '<br />* ' + uri + response.objects[i].name + '</a>';
+                anchorTag = '<a href="#/node/' + response.objects[i].id + '">';
+                htmlText += '<br />* ' + anchorTag + response.objects[i].name;
+                htmlText += '</a>';
               }
-              edgeTip.html(str);
+              edgeTip.html(htmlText);
               edgeTip.show(data, target);
             },
             function error(response) {
               var message = 'Failed to get node info for gene edge: ' +
                   response.statusCode + ' ' + response.statusText;
               $log.error(message);
-              str += message + '. Please try again later.';
-              edgeTip.html(str);
+              htmlText += '<br />' + message + '. Please try again later.';
+              edgeTip.html(htmlText);
               edgeTip.show(data, target);
             }
           );
-        }
-
-        /**
-         * Callback function to hide edge tips.
-         * @param {edge_data} data;
-         * @return {void}.
-         * ---------------------------------------------------------------------
-         * FIXME: Since the edge tip is shown asynchronously, when
-         * edgeTip.hide() is called immediately to hide the tip box, the box
-         * won't be hidden if it is shown AFTER mouseout action.  To solve this
-         * problem, edgeTip.hide() is called asynchronously after 100
-         * milliseconds.  This is more like a workaround. Not sure whether there
-         * is a better solution.
-         * ---------------------------------------------------------------------
-         */
-        function hideEdgeTip(data) {
-          setTimeout(function() {
-            edgeTip.hide();
-          }, 100);
         }
 
         network.genes(genes).edges(edges);
@@ -255,7 +248,7 @@ angular.module('adage.gene.network', [
           .call(edgeTip);
 
         geneTip.html(getGeneInfo);
-        network.onGene('click.custom', geneTip.show);
+        network.onGene('click.custom', showGeneTip);
         network.onEdge('click.custom', showEdgeTip);
 
         // Draw network svg with legend and filter.
@@ -276,7 +269,7 @@ angular.module('adage.gene.network', [
           }
         };
         addClickHandler('gene-tip', geneTip.hide);
-        addClickHandler('edge-tip', hideEdgeTip);
+        addClickHandler('edge-tip', edgeTip.hide);
       } // End of drawNetwork()
 
       EdgeService.get(

--- a/interface/src/app/gene/network/network.less
+++ b/interface/src/app/gene/network/network.less
@@ -41,15 +41,11 @@ text.legend-title {
 }
 
 .edge-tip {
-  #title {
-    text-align: center;
-  }
-
   line-height: 1;
   font-weight: bold;
   padding: 12px;
-  background: rgba(100, 150, 200, 0.9);
-  color: #fff;
+  background: Gainsboro;
+  color: black;
   border-radius: 2px;
   pointer-events: none;
 }

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -8,7 +8,6 @@
      rz-slider-model="ctrl.slider.position"
      rz-slider-options="ctrl.slider.options">
   </rzslider>
-  <br />
 </div>
 
 <!-- DO NOT put the following "chart" div into a div that is controlled by


### PR DESCRIPTION
This PR adds the hyper links on gene-gene networks **edge-tip** window to the **Node** page. 

In **network.less**, a new background color is used to distinguish the edge-tip window from gene-tip window. Some unused lines are also removed in this file..