### PR TITLE
New service of constant: ActivityDigits

### DIFF
--- a/interface/src/app/node/high_range_exp.tpl.html
+++ b/interface/src/app/node/high_range_exp.tpl.html
@@ -51,7 +51,7 @@
                         {{$index + 1}}
                       </label>
                     </td>
-                    <td>{{sample.activity.toFixed(5)}}</td>
+                    <td>{{sample.activity | number: activityDigits}}</td>
                     <td>{{sample.name}}</td>
                     <td>{{sample.ml_data_source}}</td>
                   </tr>

--- a/interface/src/app/node/node.js
+++ b/interface/src/app/node/node.js
@@ -6,6 +6,7 @@ angular.module('adage.node', [
   'ui.router',
   'ui.bootstrap',
   'ngResource',
+  'adage.utils',
   'greenelab.stats'
 ])
 
@@ -99,8 +100,8 @@ angular.module('adage.node', [
   }]
 )
 
-.directive('highRangeExp', ['$http', '$log', '$state',
-  function($http, $log, $state) {
+.directive('highRangeExp', ['$http', '$log', '$state', 'ActivityDigits',
+  function($http, $log, $state, ActivityDigits) {
     return {
       templateUrl: 'node/high_range_exp.tpl.html',
       restrict: 'E',
@@ -111,6 +112,7 @@ angular.module('adage.node', [
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';
         $scope.activities = {};
+        $scope.activityDigits = ActivityDigits;
         $scope.experiments = [];
         $scope.topMode = true;
         // If "top-exp" tag is not found, or its value is not a finite positive

--- a/interface/src/app/sample_annotation/annotation.js
+++ b/interface/src/app/sample_annotation/annotation.js
@@ -31,7 +31,8 @@ angular.module('adage.sampleAnnotation', [
 
 .controller('SampleAnnotationCtrl', [
   '$stateParams', '$q', '$log', 'errGen', 'Activity', 'Sample',
-  function($stateParams, $q, $log, errGen, Activity, Sample) {
+  'ActivityDigits',
+  function($stateParams, $q, $log, errGen, Activity, Sample, ActivityDigits) {
     var self = this;
     self.queryStatus = 'Connecting to the server ...';
 
@@ -56,7 +57,7 @@ angular.module('adage.sampleAnnotation', [
       // and sample(s):
       if ($stateParams.node) {
         self.hasNode = true;
-        self.activityPrecision = 5;
+        self.activityDigits = ActivityDigits;
         var nodeID = $stateParams.node;
         Activity.get(
           {'node': nodeID, 'sample__in': samplesInUrl},  // parameters of GET

--- a/interface/src/app/sample_annotation/annotation.spec.js
+++ b/interface/src/app/sample_annotation/annotation.spec.js
@@ -26,7 +26,8 @@ describe('sample_annotation', function() {
     beforeEach(inject(function($controller) {
       mockStateParams = {samples: '1'};
       SampleAnnotationCtrl = $controller('SampleAnnotationCtrl', {
-        $stateParams: mockStateParams
+        $stateParams: mockStateParams,
+        ActivityDigits: 5
       });
     }));
 

--- a/interface/src/app/sample_annotation/annotation.spec.js
+++ b/interface/src/app/sample_annotation/annotation.spec.js
@@ -26,8 +26,7 @@ describe('sample_annotation', function() {
     beforeEach(inject(function($controller) {
       mockStateParams = {samples: '1'};
       SampleAnnotationCtrl = $controller('SampleAnnotationCtrl', {
-        $stateParams: mockStateParams,
-        ActivityDigits: 5
+        $stateParams: mockStateParams
       });
     }));
 

--- a/interface/src/app/sample_annotation/annotation.tpl.html
+++ b/interface/src/app/sample_annotation/annotation.tpl.html
@@ -16,7 +16,7 @@
     <tr ng-repeat=
         "sample in ctrl.samples | orderBy: ctrl.hasNode ? '-activity' : 'name'">
       <td ng-if="ctrl.hasNode">
-        <strong>{{sample.activity | number: ctrl.activityPrecision}}</strong>
+        <strong>{{sample.activity | number: ctrl.activityDigits}}</strong>
       </td>
       <td>{{sample.name}}</td>
       <td ng-repeat="typeName in ctrl.uniqueAnnotationTypes">

--- a/interface/src/app/utils.js
+++ b/interface/src/app/utils.js
@@ -13,4 +13,8 @@ angular.module('adage.utils', [])
     return context + ': ' + response.status + ' ' + response.statusText;
   }
   return context;
-});
+})
+
+// Number of digits in activity value shown on frontend:
+.constant('ActivityDigits', 5)
+;


### PR DESCRIPTION
This PR includes:

* Definition of a new constant service `ActivityDigits`, which is the number of digits after decimal point in activity values;

* Usage of this service in `high-range-exp` directive on **Node** page;

* Usage of this service on sample annotation values module.