### PR TITLE
Volcano plot groups

### DIFF
--- a/interface/src/app/analyze/analysis/analysis.js
+++ b/interface/src/app/analyze/analysis/analysis.js
@@ -38,9 +38,11 @@ AnnotationType, SampleBin) {
     // TODO these exampleCols are temporarily hard-coded until a column chooser
     // feature can be added
     exampleCols: [
+      {'typename': 'strain'},
       {'typename': 'genotype'},
       {'typename': 'medium'},
-      {'typename': 'strain'}
+      {'typename': 'temperature'},
+      {'typename': 'treatment'}
     ]
   };
 

--- a/interface/src/app/analyze/analysis/analysis.js
+++ b/interface/src/app/analyze/analysis/analysis.js
@@ -78,13 +78,14 @@ AnnotationType, SampleBin) {
           {'type': 'formula', 'field': 'normval', 'expr': 'abs(datum.value)'}
         ]
       }, {
-        // this dataset "streamed" in via ngVega from heatmapData
+        // these datasets "streamed" in via ngVega from heatmapData
         'name': 'samples'
+      // }, {
+      // FIXME: this dataset must fit a vega-compatible format to be included
+      //   'name': 'sampleGroups'
       }, {
-        // this dataset "streamed" in via ngVega from heatmapData
         'name': 'nodeOrder'
       }, {
-        // this dataset "streamed" in via ngVega from heatmapData
         'name': 'sample_objects'
       }, {
         // compute minimum normalized value for each node (across samples)

--- a/interface/src/app/analyze/analysis/analysis.less
+++ b/interface/src/app/analyze/analysis/analysis.less
@@ -1,3 +1,9 @@
+.sample-group-a {
+  background-color: #b7baff;
+}
+.sample-group-b {
+  background-color: #fee7a9;
+}
 .as-sortable-item, .as-sortable-placeholder {
   display: table-row;
 }

--- a/interface/src/app/analyze/analysis/analysis.less
+++ b/interface/src/app/analyze/analysis/analysis.less
@@ -25,9 +25,7 @@ th .row-control, thead .row-control {
   visibility: hidden;
 }
 
-// sample group highlighting
-@sample-group-a: #b7baff;
-@sample-group-b: #fee7a9;
+// use special colors for highlighting sample groups (see less/variables.less)
 .table-row-variant(sample-group-a; @sample-group-a);
 .table-row-variant(sample-group-b; @sample-group-b);
 

--- a/interface/src/app/analyze/analysis/analysis.less
+++ b/interface/src/app/analyze/analysis/analysis.less
@@ -1,9 +1,37 @@
-.sample-group-a {
-  background-color: #b7baff;
+/*
+ * styles to make sampleBin editing controls more user-friendly
+ */
+.row-control {
+  float: none;
+  .opacity(.2);
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    cursor: pointer;
+    .opacity(.5);
+  }
+
+  button& {
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+    -webkit-appearance: none;
+  }
 }
-.sample-group-b {
-  background-color: #fee7a9;
+// allow us to use controls to help align headers, but don't show them
+th .row-control, thead .row-control {
+  visibility: hidden;
 }
+
+// sample group highlighting
+@sample-group-a: #b7baff;
+@sample-group-b: #fee7a9;
+.table-row-variant(sample-group-a; @sample-group-a);
+.table-row-variant(sample-group-b; @sample-group-b);
+
+// helper styles for as-sortable control
 .as-sortable-item, .as-sortable-placeholder {
   display: table-row;
 }

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -1,27 +1,35 @@
 <!--
   TODO each sample should be built using a reusable Angular directive
 -->
-<h1>Samples <small>(drag to reorder)</small></h1>
+<h1>Samples
+  <small>(drag <i class="fa fa-bars" aria-hidden="true"></i> to reorder,
+    click <i class="fa fa-times" aria-hidden="true"></i> to delete,
+    choose <input type="radio" disabled> to set group)</small>
+</h1>
 <status-bar msg-text="analysis.status"></status-bar>
 <!-- TODO need a tool to select and order annotation columns -->
 <table class="table table-hover">
   <thead>
     <tr>
-      <td>
-        group
-      </td>
-      <td>id</td>
-      <td>ML Data Source</td>
-      <td>Sample Name</td>
-      <td ng-repeat="at in analysis.exampleCols">{{
+      <th> </th>
+      <th>
+        <span class="row-control">
+          <i class="fa fa-bars" aria-hidden="true"></i>
+        </span>
+        ML Data Source
+      </th>
+      <th>id</th>
+      <th>Sample Name</th>
+      <th ng-repeat="at in analysis.exampleCols">{{
         at.typename
-      }}</td>
-      <td>&nbsp;</td>
+      }}</th>
     </tr>
   </thead>
   <tbody ng-model="sb.heatmapData.samples" as-sortable="sortableOptions">
-    <tr ng-repeat="id in sb.heatmapData.samples" as-sortable-item>
-      <td>
+    <tr ng-repeat="id in sb.heatmapData.samples"
+        ng-mouseover="showControls = true" ng-mouseleave="showControls = false"
+        ng-class="'sample-' + sb.sampleGroups[id]" as-sortable-item>
+      <td class="row-control">
         <input type="radio" ng-model="sb.sampleGroups[id]"
             name="{{id}}-group" value="group-a"
             class="sample-group-a" aria-label="group a">
@@ -30,22 +38,24 @@
             class="sample-group-b" aria-label="group b">
         <input type="radio" ng-model="sb.sampleGroups[id]"
             name="{{id}}-group" value="other"
-            class="sample-group-o" aria-label="other" checked>
-      </td>
-      <td>{{id}}</td>
-      <td as-sortable-item-handle>{{
-        sb.sampleData[id].ml_data_source
-      }}</td>
-      <td>{{sb.sampleData[id].name}}</td>
-      <td ng-repeat="at in analysis.exampleCols">{{
-        sb.sampleData[id].annotations[at.typename]
-      }}</td>
-      <td>
-        <button type="button" class="btn close"
+            class="sample-other" aria-label="other">
+        &nbsp;
+        <button type="button" class="btn row-control"
             ng-click="sb.removeSample(id)" aria-label="Delete">
           <i class="fa fa-times" aria-hidden="true"></i>
         </button>
       </td>
+      <td as-sortable-item-handle>
+        <span class="row-control">
+          <i class="fa fa-bars" aria-hidden="true"></i>
+        </span>
+        {{sb.sampleData[id].ml_data_source}}
+      </td>
+      <td>{{id}}</td>
+      <td>{{sb.sampleData[id].name}}</td>
+      <td ng-repeat="at in analysis.exampleCols">{{
+        sb.sampleData[id].annotations[at.typename]
+      }}</td>
     </tr>
   </tbody>
 </table>
@@ -66,5 +76,3 @@
     </button>
   </div>
 </nav>
-
-<pre>{{sb.sampleGroups | json}}</pre>

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -16,6 +16,48 @@
       }}</td>
     </tr>
   </thead>
+  <tbody class="sample-group-a" ng-model="sb.heatmapData.samplesA" as-sortable="sortableOptions">
+    <tr as-sortable-item>
+      <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+    </tr>
+    <tr ng-repeat="id in sb.heatmapData.samplesA" as-sortable-item>
+      <td>
+        <button type="button" class="btn close"
+        ng-click="sb.removeSample(id)" aria-label="Delete">
+          <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
+      </td>
+      <td>{{id}}</td>
+      <td as-sortable-item-handle>{{
+        sb.sampleData[id].ml_data_source
+      }}</td>
+      <td>{{sb.sampleData[id].name}}</td>
+      <td ng-repeat="at in analysis.exampleCols">{{
+        sb.sampleData[id].annotations[at.typename]
+      }}</td>
+    </tr>
+  </tbody>
+  <tbody class="sample-group-b" ng-model="sb.heatmapData.samplesB" as-sortable="sortableOptions">
+    <tr as-sortable-item>
+      <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+    </tr>
+    <tr ng-repeat="id in sb.heatmapData.samplesB" as-sortable-item>
+      <td>
+        <button type="button" class="btn close"
+        ng-click="sb.removeSample(id)" aria-label="Delete">
+          <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
+      </td>
+      <td>{{id}}</td>
+      <td as-sortable-item-handle>{{
+        sb.sampleData[id].ml_data_source
+      }}</td>
+      <td>{{sb.sampleData[id].name}}</td>
+      <td ng-repeat="at in analysis.exampleCols">{{
+        sb.sampleData[id].annotations[at.typename]
+      }}</td>
+    </tr>
+  </tbody>
   <tbody ng-model="sb.heatmapData.samples" as-sortable="sortableOptions">
     <tr ng-repeat="id in sb.heatmapData.samples" as-sortable-item>
       <td>

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -7,64 +7,30 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <td>&nbsp;</td>
+      <td>
+        group
+      </td>
       <td>id</td>
       <td>ML Data Source</td>
       <td>Sample Name</td>
       <td ng-repeat="at in analysis.exampleCols">{{
         at.typename
       }}</td>
+      <td>&nbsp;</td>
     </tr>
   </thead>
-  <tbody class="sample-group-a" ng-model="sb.heatmapData.samplesA" as-sortable="sortableOptions">
-    <tr as-sortable-item>
-      <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-    </tr>
-    <tr ng-repeat="id in sb.heatmapData.samplesA" as-sortable-item>
-      <td>
-        <button type="button" class="btn close"
-        ng-click="sb.removeSample(id)" aria-label="Delete">
-          <i class="fa fa-times" aria-hidden="true"></i>
-        </button>
-      </td>
-      <td>{{id}}</td>
-      <td as-sortable-item-handle>{{
-        sb.sampleData[id].ml_data_source
-      }}</td>
-      <td>{{sb.sampleData[id].name}}</td>
-      <td ng-repeat="at in analysis.exampleCols">{{
-        sb.sampleData[id].annotations[at.typename]
-      }}</td>
-    </tr>
-  </tbody>
-  <tbody class="sample-group-b" ng-model="sb.heatmapData.samplesB" as-sortable="sortableOptions">
-    <tr as-sortable-item>
-      <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-    </tr>
-    <tr ng-repeat="id in sb.heatmapData.samplesB" as-sortable-item>
-      <td>
-        <button type="button" class="btn close"
-        ng-click="sb.removeSample(id)" aria-label="Delete">
-          <i class="fa fa-times" aria-hidden="true"></i>
-        </button>
-      </td>
-      <td>{{id}}</td>
-      <td as-sortable-item-handle>{{
-        sb.sampleData[id].ml_data_source
-      }}</td>
-      <td>{{sb.sampleData[id].name}}</td>
-      <td ng-repeat="at in analysis.exampleCols">{{
-        sb.sampleData[id].annotations[at.typename]
-      }}</td>
-    </tr>
-  </tbody>
   <tbody ng-model="sb.heatmapData.samples" as-sortable="sortableOptions">
     <tr ng-repeat="id in sb.heatmapData.samples" as-sortable-item>
       <td>
-        <button type="button" class="btn close"
-        ng-click="sb.removeSample(id)" aria-label="Delete">
-          <i class="fa fa-times" aria-hidden="true"></i>
-        </button>
+        <input type="radio" ng-model="sb.sampleGroups[id]"
+            name="{{id}}-group" value="group-a"
+            class="sample-group-a" aria-label="group a">
+        <input type="radio" ng-model="sb.sampleGroups[id]"
+            name="{{id}}-group" value="group-b"
+            class="sample-group-b" aria-label="group b">
+        <input type="radio" ng-model="sb.sampleGroups[id]"
+            name="{{id}}-group" value="other"
+            class="sample-group-o" aria-label="other" checked>
       </td>
       <td>{{id}}</td>
       <td as-sortable-item-handle>{{
@@ -74,6 +40,12 @@
       <td ng-repeat="at in analysis.exampleCols">{{
         sb.sampleData[id].annotations[at.typename]
       }}</td>
+      <td>
+        <button type="button" class="btn close"
+            ng-click="sb.removeSample(id)" aria-label="Delete">
+          <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
+      </td>
     </tr>
   </tbody>
 </table>
@@ -94,3 +66,5 @@
     </button>
   </div>
 </nav>
+
+<pre>{{sb.sampleGroups | json}}</pre>

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -28,15 +28,15 @@
   <tbody ng-model="sb.heatmapData.samples" as-sortable="sortableOptions">
     <tr ng-repeat="id in sb.heatmapData.samples"
         ng-mouseover="showControls = true" ng-mouseleave="showControls = false"
-        ng-class="'sample-' + sb.sampleGroups[id]" as-sortable-item>
+        ng-class="'sample-' + sb.sampleToGroup[id]" as-sortable-item>
       <td class="row-control">
-        <input type="radio" ng-model="sb.sampleGroups[id]"
+        <input type="radio" ng-model="sb.sampleToGroup[id]"
             name="{{id}}-group" value="group-a"
             class="sample-group-a" aria-label="group a">
-        <input type="radio" ng-model="sb.sampleGroups[id]"
+        <input type="radio" ng-model="sb.sampleToGroup[id]"
             name="{{id}}-group" value="group-b"
             class="sample-group-b" aria-label="group b">
-        <input type="radio" ng-model="sb.sampleGroups[id]"
+        <input type="radio" ng-model="sb.sampleToGroup[id]"
             name="{{id}}-group" value="other"
             class="sample-other" aria-label="other">
         &nbsp;

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -20,7 +20,7 @@ function($log, $cacheFactory, $q, Sample, Activity) {
       samples: [],
       nodeOrder: []
     },
-    sampleGroups: {}, // this is a hash from sample id to group name
+    sampleToGroup: {}, // this is a hash from sample id to group name
     sampleData: {},
     sampleCache: $cacheFactory('sample'),
     activityCache: $cacheFactory('activity'),
@@ -32,7 +32,7 @@ function($log, $cacheFactory, $q, Sample, Activity) {
             ' already in the sample list; ignoring.');
       } else {
         this.heatmapData.samples.push(+id);
-        this.sampleGroups[+id] = 'other';
+        this.sampleToGroup[+id] = 'other';
         // TODO when cache generalized: start pre-fetching sample data here
         this.heatmapData.nodeOrder = [];  // reset to default order
       }
@@ -41,7 +41,7 @@ function($log, $cacheFactory, $q, Sample, Activity) {
     removeSample: function(id) {
       var pos = this.heatmapData.samples.indexOf(+id);
       this.heatmapData.samples.splice(pos, 1);
-      delete this.sampleGroups[+id];
+      delete this.sampleToGroup[+id];
       this.heatmapData.nodeOrder = [];  // reset to default order
       this.rebuildHeatmapActivity(this.heatmapData.samples);
     },
@@ -80,21 +80,20 @@ function($log, $cacheFactory, $q, Sample, Activity) {
       }
     },
 
-    getSampleGroups: function() {
-      var keys = Object.keys(this.sampleGroups);
+    getSamplesByGroup: function() {
+      var keys = Object.keys(this.sampleToGroup);
       var samplesByGroup = {};
-      var i;
+      var i, groupForThisKey;
 
-      // each distinct value in sampleGroups becomes a key in samplesByGroup,
-      // and the keys of sampleGroups are collected in a list within each
+      // each distinct value in sampleToGroup becomes a key in samplesByGroup,
+      // and the keys of sampleToGroup are collected in a list within each
       // corresponding value of samplesByGroup
       for (i = 0; i < keys.length; i++) {
-        if (samplesByGroup[this.sampleGroups[+keys[i]]]) {
-          samplesByGroup[this.sampleGroups[+keys[i]]].push(+keys[i]);
-        } else {
-          samplesByGroup[this.sampleGroups[+keys[i]]] = [];
-          samplesByGroup[this.sampleGroups[+keys[i]]].push(+keys[i]);
+        groupForThisKey = this.sampleToGroup[+keys[i]];
+        if (!samplesByGroup[groupForThisKey]) {
+          samplesByGroup[groupForThisKey] = [];
         }
+        samplesByGroup[groupForThisKey].push(+keys[i]);
       }
 
       return samplesByGroup;

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -18,6 +18,8 @@ function($log, $cacheFactory, $q, Sample, Activity) {
   var SampleBin = {
     heatmapData: {
       samples: [],
+      samplesA: [],
+      samplesB: [],
       nodeOrder: []
     },
     sampleData: {},

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -80,6 +80,26 @@ function($log, $cacheFactory, $q, Sample, Activity) {
       }
     },
 
+    getSampleGroups: function() {
+      var keys = Object.keys(this.sampleGroups);
+      var samplesByGroup = {};
+      var i;
+
+      // each distinct value in sampleGroups becomes a key in samplesByGroup,
+      // and the keys of sampleGroups are collected in a list within each
+      // corresponding value of samplesByGroup
+      for (i = 0; i < keys.length; i++) {
+        if (samplesByGroup[this.sampleGroups[+keys[i]]]) {
+          samplesByGroup[this.sampleGroups[+keys[i]]].push(+keys[i]);
+        } else {
+          samplesByGroup[this.sampleGroups[+keys[i]]] = [];
+          samplesByGroup[this.sampleGroups[+keys[i]]].push(+keys[i]);
+        }
+      }
+
+      return samplesByGroup;
+    },
+
     getSampleData: function(id) {
       var sampleObj = this.sampleData[id];
       sampleObj.activity = this.activityCache.get(id).map(

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -18,10 +18,9 @@ function($log, $cacheFactory, $q, Sample, Activity) {
   var SampleBin = {
     heatmapData: {
       samples: [],
-      samplesA: [],
-      samplesB: [],
       nodeOrder: []
     },
+    sampleGroups: {}, // this is a hash from sample id to group name
     sampleData: {},
     sampleCache: $cacheFactory('sample'),
     activityCache: $cacheFactory('activity'),
@@ -33,6 +32,7 @@ function($log, $cacheFactory, $q, Sample, Activity) {
             ' already in the sample list; ignoring.');
       } else {
         this.heatmapData.samples.push(+id);
+        this.sampleGroups[+id] = 'other';
         // TODO when cache generalized: start pre-fetching sample data here
         this.heatmapData.nodeOrder = [];  // reset to default order
       }
@@ -41,6 +41,7 @@ function($log, $cacheFactory, $q, Sample, Activity) {
     removeSample: function(id) {
       var pos = this.heatmapData.samples.indexOf(+id);
       this.heatmapData.samples.splice(pos, 1);
+      delete this.sampleGroups[+id];
       this.heatmapData.nodeOrder = [];  // reset to default order
       this.rebuildHeatmapActivity(this.heatmapData.samples);
     },

--- a/interface/src/less/variables.less
+++ b/interface/src/less/variables.less
@@ -9,3 +9,11 @@
 
 @sansFontFamily: 'Roboto', sans-serif;
 
+
+/**
+ * Color palate
+ */
+
+// used for highlighting sample groups in sampleBin.tpl.html
+@sample-group-a: #b7baff;
+@sample-group-b: #fee7a9;


### PR DESCRIPTION
This set of changes allows users to put each sample into one of three groups, labeled in the code as "group a," "group b" and "other." A convenience method `getSampleGroups()` is also supplied, making it easier to retrieve the list of samples within each group.

No demo server running yet. I will post here when it's up.