### PR TITLE
New model of gene-sample expression value and management command to load data sheet into database

### DIFF
--- a/adage/analyze/management/commands/add_ml_model.py
+++ b/adage/analyze/management/commands/add_ml_model.py
@@ -69,7 +69,7 @@ def add_ml_model(ml_model_name, organism_tax_id, directed_edge):
     except Organism.DoesNotExist:
         raise Exception("Input organism_tax_id is not found in the database. "
                         "Please use the management command "
-                        "'organism_create_or_update.py' in djago-organism "
+                        "'organism_create_or_update.py' in django-organisms "
                         "package to create this organism.")
 
     MLModel.objects.create(title=ml_model_name,

--- a/adage/analyze/management/commands/import_gene_sample_expr.py
+++ b/adage/analyze/management/commands/import_gene_sample_expr.py
@@ -70,7 +70,7 @@ def import_expr(file_handle, organism_tax_id):
     except Organism.DoesNotExist:
         raise Exception("Input organism_tax_id is not found in the database. "
                         "Please use the management command "
-                        "'organism_create_or_update.py' in djago-organism "
+                        "'organism_create_or_update.py' in django-organisms "
                         "package to create this organism.")
 
     # Enclose reading/importing process in a transaction context manager.
@@ -114,7 +114,7 @@ def read_header(tokens, samples):
                 samples.append(sample)
             except Sample.DoesNotExist:
                 samples.append(None)
-                logger.warn(
+                logger.warning(
                     "Input file line #1: data_source in column #%d not found "
                     "in the database: %s", index + 2, data_source)
 
@@ -148,7 +148,7 @@ def import_data_line(line_num, tokens, samples, organism):
     except Gene.DoesNotExist:
         # If a gene is not found in database, generate a warning message
         # and skip this line.
-        logger.warn(
+        logger.warning(
             "Input file line #%d: gene name %s (column #1) not found in "
             "database", line_num, gene_name)
         return

--- a/adage/analyze/management/commands/import_gene_sample_expr.py
+++ b/adage/analyze/management/commands/import_gene_sample_expr.py
@@ -2,13 +2,13 @@
 
 """
 This management command reads an input file of gene-sample expression values
-and loads the valid data into the database.  It should be invoked like this:
+and loads the valid data into database.  It should be invoked like this:
 
   python manage.py import_gene_sample_expr <expression_filename>
 
 If a data source (on the first row) or gene name (on the first column) is
 not found in the database, a warning message will be generated and the
-corresponding rows or columns will be skipped.
+corresponding column or row will be skipped.
 """
 
 

--- a/adage/analyze/management/commands/import_gene_sample_expr.py
+++ b/adage/analyze/management/commands/import_gene_sample_expr.py
@@ -2,11 +2,11 @@
 
 """
 This management command reads an input file of gene-sample expression values
-and load the valild data into the database.  It should be invoked like this:
+and loads the valid data into the database.  It should be invoked like this:
 
   python manage.py import_gene_sample_expr <expression_filename>
 
-If a data source (on the first row) or gene name (on the c=first column) is
+If a data source (on the first row) or gene name (on the first column) is
 not found in the database, a warning message will be generated and the
 corresponding rows or columns will be skipped.
 """

--- a/adage/analyze/management/commands/import_gene_sample_expr.py
+++ b/adage/analyze/management/commands/import_gene_sample_expr.py
@@ -2,19 +2,35 @@
 
 """
 This management command reads an input file of gene-sample expression values
-and loads the valid data into database.  It should be invoked like this:
+and loads the valid data into the database.  It should be invoked like this:
 
-  python manage.py import_gene_sample_expr <expression_filename>
+  python manage.py import_gene_sample_expr <expression_filename> \
+<organism_tax_id>
 
-If a data source (on the first row) or gene name (on the first column) is
-not found in the database, a warning message will be generated and the
-corresponding column or row will be skipped.
+The two required arguments are:
+  (1) expression_filename: input file of gene-sample expression values;
+  (2) organism_tax_id: taxonomy ID of the organism.
+
+For example, to load the sample-gene expression values for the organism
+"Pseudomonas aeruginosa" (whose taxonomy ID is 208964), the command will be:
+  python manage.py input_filename 208964
+
+IMPORTANT:
+(1) Before running this command, please make sure that "django-organisms"
+package has been installed and organism_tax_id already exists in the database.
+If organism_tax_id is not in the database yet, please use the management
+command "organisms_create_or_update.py" (in "django-organisms" package)
+to add it.
+(2) If a data source (on the first row of input file) or gene name (on the
+first column of input file) is not found in the database, a warning message
+will be generated and the corresponding column or row will be skipped.
 """
 
 
 from __future__ import print_function
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from organisms.models import Organism
 from genes.models import Gene
 from analyze.models import Sample, ExpressionValue
 
@@ -28,10 +44,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('expression_filename', type=file)
+        parser.add_argument('organism_tax_id', type=int)
 
     def handle(self, **options):
         try:
-            import_expr(options['expression_filename'])
+            import_expr(options['expression_filename'],
+                        options['organism_tax_id'])
             self.stdout.write(self.style.NOTICE(
                 "Imported gene-sample expression values successfully"))
         except Exception as e:
@@ -40,11 +58,20 @@ class Command(BaseCommand):
                 "values: %s" % e)
 
 
-def import_expr(file_handle):
+def import_expr(file_handle, organism_tax_id):
     """
     Function that reads input file and load gene-sample expression values
     into the database.
     """
+
+    # Make sure input organism_tax_id already exists in database.
+    try:
+        organism = Organism.objects.get(taxonomy_id=organism_tax_id)
+    except Organism.DoesNotExist:
+        raise Exception("Input organism_tax_id is not found in the database. "
+                        "Please use the management command "
+                        "'organism_create_or_update.py' in djago-organism "
+                        "package to create this organism.")
 
     # Enclose reading/importing process in a transaction context manager.
     # Any exception raised inside the manager will terminate the transaction
@@ -57,7 +84,7 @@ def import_expr(file_handle):
                 tokens = tokens[1:]
                 read_header(tokens, samples)
             else:
-                import_data_line(line_index + 1, tokens, samples)
+                import_data_line(line_index + 1, tokens, samples, organism)
 
 
 def read_header(tokens, samples):
@@ -67,7 +94,7 @@ def read_header(tokens, samples):
     using "ml_data_source" field. If a token does not match any sample's
     ml_data_source, put None into "samples".)
 
-    An exception will be raised if any of the following errors is detected:
+    An exception will be raised if any of the following errors are detected:
       * Sample token is blank (null or consists of space characters only);
       * Sample token is duplicate;
     """
@@ -92,10 +119,10 @@ def read_header(tokens, samples):
                     "in the database: %s", index + 2, data_source)
 
 
-def import_data_line(line_num, tokens, samples):
+def import_data_line(line_num, tokens, samples, organism):
     """
     Function that imports numerical values in input tokens into the database.
-    An exception will be raised if any of the following errors is detected:
+    An exception will be raised if any of the following errors are detected:
       * The number of columns on this line is not equal to the number of
         samples plus 1.
       * The gene's "systematic_name" field (column #1) is blank;
@@ -109,17 +136,21 @@ def import_data_line(line_num, tokens, samples):
 
     gene_name = tokens[0]
     if not gene_name or gene_name.isspace():
-        raise Exception("Input file line #%d: gene systematic_name (column #1)"
+        raise Exception("Input file line #%d: gene name (column #1)"
                         " is blank" % line_num)
 
     try:
-        gene = Gene.objects.get(systematic_name=gene_name)
+        gene = Gene.objects.get(systematic_name=gene_name, organism=organism)
+    except Gene.MultipleObjectsReturned:
+        raise Exception("Input file line #%d: gene name %s (column #1) matches"
+                        " multiple genes in the database" %
+                        (line_num, gene_name))
     except Gene.DoesNotExist:
         # If a gene is not found in database, generate a warning message
         # and skip this line.
         logger.warn(
-            "Input file line #%d: gene systematic_name (column #1) is not "
-            "found in the database: %s", line_num, gene_name)
+            "Input file line #%d: gene name %s (column #1) not found in "
+            "database", line_num, gene_name)
         return
 
     values = tokens[1:]
@@ -131,8 +162,8 @@ def import_data_line(line_num, tokens, samples):
         try:
             float_val = float(value)
         except ValueError:
-            raise Exception("Input file line #%d column #%d: %s is not numeric"
-                            % (line_num, col_num, value))
+            raise Exception("Input file line #%d column #%d: expression value "
+                            "%s not numeric" % (line_num, col_num, value))
         if sample is not None:
             records.append(
                 ExpressionValue(sample=sample, gene=gene, value=float_val))

--- a/adage/analyze/management/commands/import_gene_sample_expr.py
+++ b/adage/analyze/management/commands/import_gene_sample_expr.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+"""
+This management command reads an input file of gene-sample expression values
+and load the valild data into the database.  It should be invoked like this:
+
+  python manage.py import_gene_sample_expr <expression_filename>
+
+If a data source (on the first row) or gene name (on the c=first column) is
+not found in the database, a warning message will be generated and the
+corresponding rows or columns will be skipped.
+"""
+
+
+from __future__ import print_function
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from genes.models import Gene
+from analyze.models import Sample, ExpressionValue
+
+import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class Command(BaseCommand):
+    help = ("Import gene-sample expression values from an input file.")
+
+    def add_arguments(self, parser):
+        parser.add_argument('expression_filename', type=file)
+
+    def handle(self, **options):
+        try:
+            import_expr(options['expression_filename'])
+            self.stdout.write(self.style.NOTICE(
+                "Imported gene-sample expression values successfully"))
+        except Exception as e:
+            raise CommandError(
+                "Raised exception when importing gene-sample expression "
+                "values: %s" % e)
+
+
+def import_expr(file_handle):
+    """
+    Function that reads input file and load gene-sample expression values
+    into the database.
+    """
+
+    # Enclose reading/importing process in a transaction context manager.
+    # Any exception raised inside the manager will terminate the transaction
+    # and roll back the database.
+    with transaction.atomic():
+        samples = []
+        for line_index, line in enumerate(file_handle):
+            tokens = line.rstrip('\r\n').split('\t')
+            if line_index == 0:
+                tokens = tokens[1:]
+                read_header(tokens, samples)
+            else:
+                import_data_line(line_index + 1, tokens, samples)
+
+
+def read_header(tokens, samples):
+    """
+    Read input tokens on header line and save the corresponding sample
+    object into "samples". (Each token will be searched in the database
+    using "ml_data_source" field. If a token does not match any sample's
+    ml_data_source, put None into "samples".)
+
+    An exception will be raised if any of the following errors is detected:
+      * Sample token is blank (null or consists of space characters only);
+      * Sample token is duplicate;
+    """
+
+    token_set = set()
+    for index, data_source in enumerate(tokens):
+        if not data_source or data_source.isspace():
+            raise Exception("Input file line #1 column #%d: blank data_source"
+                            % index + 2)
+        elif data_source in token_set:
+            raise Exception("Input file line #1 column #%d: %s is duplicate" %
+                            (index + 2, data_source))
+        else:
+            try:
+                token_set.add(data_source)
+                sample = Sample.objects.get(ml_data_source=data_source)
+                samples.append(sample)
+            except Sample.DoesNotExist:
+                samples.append(None)
+                logger.warn(
+                    "Input file line #1: data_source in column #%d not found "
+                    "in the database: %s", index + 2, data_source)
+
+
+def import_data_line(line_num, tokens, samples):
+    """
+    Function that imports numerical values in input tokens into the database.
+    An exception will be raised if any of the following errors is detected:
+      * The number of columns on this line is not equal to the number of
+        samples plus 1.
+      * The gene's "systematic_name" field (column #1) is blank;
+      * Data field (from column #2 to the end) can not be converted into a
+        float type.
+    """
+
+    if len(tokens) != len(samples) + 1:
+        raise Exception("Input file line #%d: Number of columns is not %d" %
+                        (line_num, len(samples) + 1))
+
+    gene_name = tokens[0]
+    if not gene_name or gene_name.isspace():
+        raise Exception("Input file line #%d: gene systematic_name (column #1)"
+                        " is blank" % line_num)
+
+    try:
+        gene = Gene.objects.get(systematic_name=gene_name)
+    except Gene.DoesNotExist:
+        # If a gene is not found in database, generate a warning message
+        # and skip this line.
+        logger.warn(
+            "Input file line #%d: gene systematic_name (column #1) is not "
+            "found in the database: %s", line_num, gene_name)
+        return
+
+    values = tokens[1:]
+    # To speed up the importing process, all expression values on current data
+    # line will be saved in "records" and created in bulk at the end.
+    records = []
+    col_num = 2   # Expression values start from column #2.
+    for sample, value in zip(samples, values):
+        try:
+            float_val = float(value)
+        except ValueError:
+            raise Exception("Input file line #%d column #%d: %s is not numeric"
+                            % (line_num, col_num, value))
+        if sample is not None:
+            records.append(
+                ExpressionValue(sample=sample, gene=gene, value=float_val))
+        col_num += 1
+    ExpressionValue.objects.bulk_create(records)  # Create records in bulk.

--- a/adage/analyze/migrations/0006_expressionvalue.py
+++ b/adage/analyze/migrations/0006_expressionvalue.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('genes', '0001_initial'),
+        ('analyze', '0005_auto_20160915_1523'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ExpressionValue',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('value', models.FloatField()),
+                ('gene', models.ForeignKey(to='genes.Gene', on_delete=django.db.models.deletion.PROTECT)),
+                ('sample', models.ForeignKey(to='analyze.Sample', on_delete=django.db.models.deletion.PROTECT)),
+            ],
+        ),
+    ]

--- a/adage/analyze/migrations/0007_auto_20170404_1616.py
+++ b/adage/analyze/migrations/0007_auto_20170404_1616.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analyze', '0006_expressionvalue'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='expressionvalue',
+            unique_together=set([('sample', 'gene')]),
+        ),
+    ]

--- a/adage/analyze/models.py
+++ b/adage/analyze/models.py
@@ -218,3 +218,17 @@ class Participation(models.Model):
         return "Model: %s, Node: %s, Gene: %s" % (self.node.mlmodel.title,
                                                   self.node.name,
                                                   self.gene.entrezid)
+
+
+class ExpressionValue(models.Model):
+    """
+    This class models the many-to-many relationship between Sample and Gene.
+    Each sample/gene pair has an expression value of floating type.
+    """
+    sample = models.ForeignKey(Sample, on_delete=models.PROTECT)
+    gene = models.ForeignKey(Gene, on_delete=models.PROTECT)
+    value = models.FloatField()
+
+    def __unicode__(self):
+        return "Sample %s and Gene %s with expression value %f" % (
+            self.sample.name, self.gene.entrezid, self.value)

--- a/adage/analyze/models.py
+++ b/adage/analyze/models.py
@@ -222,13 +222,17 @@ class Participation(models.Model):
 
 class ExpressionValue(models.Model):
     """
-    This class models the many-to-many relationship between Sample and Gene.
-    Each sample/gene pair has an expression value of floating type.
+    ExpressionValue models the many-to-many relationship between Gene and
+    Sample.  For each ExpressionValue, Gene 'gene' has RMA processed and
+    zero-one normalized gene expression 'value' in Sample 'sample'.
     """
     sample = models.ForeignKey(Sample, on_delete=models.PROTECT)
     gene = models.ForeignKey(Gene, on_delete=models.PROTECT)
     value = models.FloatField()
 
+    class Meta:
+        unique_together = ('sample', 'gene')
+
     def __unicode__(self):
-        return "Sample %s and Gene %s with expression value %f" % (
-            self.sample.name, self.gene.entrezid, self.value)
+        return "Expression value %f for Sample %s and Gene %s" % (
+            self.value, self.sample.name, self.gene.entrezid)


### PR DESCRIPTION
Although this PR includes 4 files, you can skip these two:
* migrations/0006_expressionvalue.py (generated by database migration)
* data/all-pseudomonas-gene-normalized.pcl (datasheet provided by Jie)

`models.py` includes a new class to model the gene-sample relationship.
`import_gene_sample_expr.py` is the management command to read the data sheet into backend database.
