### PR TITLE
New feature in gene-gene Network: Coloring the gene circles

### DIFF
--- a/adage/analyze/api.py
+++ b/adage/analyze/api.py
@@ -349,8 +349,8 @@ class ActivityResource(ModelResource):
 
 
 class EdgeResource(ModelResource):
-    gene1 = fields.ForeignKey(GeneResource, "gene1", full=True)
-    gene2 = fields.ForeignKey(GeneResource, "gene2", full=True)
+    gene1 = fields.IntegerField(attribute='gene1_id', null=False)
+    gene2 = fields.IntegerField(attribute='gene2_id', null=False)
     mlmodel = fields.IntegerField(attribute='mlmodel_id', null=False)
 
     class Meta:

--- a/interface/bower.json
+++ b/interface/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adage",
-  "version": "0.5.0b",
+  "version": "0.6.0b",
   "homepage": "http://adage.greenelab.com",
   "authors": [
     "Matt Huyck (http://www.greenelab.com/staff)",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Matt Huyck",
   "name": "adage",
-  "version": "0.5.0b",
+  "version": "0.6.0b",
   "description": "Adage Web Server",
   "homepage": "http://adage.greenelab.com",
   "license": "(MIT AND BSD-3-Clause)",

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -7,12 +7,13 @@ angular.module('adage.gene.network', [
   'ui.bootstrap',
   'ngResource',
   'rzModule',
-  'adage.utils'
+  'adage.utils',
+  'adage.gene.resource'
 ])
 
 .config(['$stateProvider', function($stateProvider) {
   $stateProvider.state('gene_network', {
-    url: '/gene_network/?genes&mlmodel',
+    url: '/gene_network/?genes&mlmodel&base_group&comp_group',
     views: {
       main: {
         templateUrl: 'gene/network/network.tpl.html',
@@ -40,7 +41,7 @@ angular.module('adage.gene.network', [
   });
 }])
 
-.factory('EdgeService', ['$resource', 'ApiBasePath',
+.factory('Edge', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
   // Possible parameters for this endpoint when making a query are:
   // {
@@ -52,21 +53,34 @@ angular.module('adage.gene.network', [
   }
 ])
 
-.factory('NodeService', ['$resource', 'ApiBasePath',
+.factory('Node', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
     return $resource(ApiBasePath + 'node');
   }
 ])
 
+.factory('ExpressionValue', ['$resource', 'ApiBasePath',
+  function($resource, ApiBasePath) {
+    return $resource(ApiBasePath + 'expressionvalue');
+  }
+])
+
 .controller('GeneNetworkCtrl',
-  ['$stateParams', 'EdgeService', 'NodeService', '$log', 'errGen',
-    function GeneNetworkController($stateParams, EdgeService, NodeService,
-                                   $log, errGen) {
+  ['$stateParams', 'Edge', 'Node', 'Gene', 'ExpressionValue', '$log', 'errGen',
+    function GeneNetworkController($stateParams, Edge, Node, Gene,
+                                   ExpressionValue, $log, errGen) {
       var self = this;
       // Do nothing if no genes are specified in URL.
       if (!$stateParams.genes || !$stateParams.genes.split(',').length) {
         self.statusMessage = 'No genes are specified.';
         return;
+      }
+
+      var baseSamples = $stateParams.base_group;
+      var compSamples = $stateParams.comp_group;
+      var geneColored = true;
+      if (!baseSamples || !compSamples) {
+        geneColored = false;
       }
 
       // The following properties of "self" will be available to HTML.
@@ -87,9 +101,9 @@ angular.module('adage.gene.network', [
           .geneText(function(d) {
             return d.label;
           })
-          .legendStart(minCorrelation)
-          .legendEnd(maxCorrelation)
-          .legendText('Correlation');
+          .edgeLegendStart(minCorrelation)
+          .edgeLegendEnd(maxCorrelation)
+          .edgeLegendText('Edge Correlation');
 
       var geneTip, edgeTip;
 
@@ -126,52 +140,85 @@ angular.module('adage.gene.network', [
         }
       };
 
-      var urlGenes = $stateParams.genes.split(',');
+      // Function that returns unique numerical gene IDs included in the URL.
+      var getGenesInURL = function(genesParam) {
+        var arr = [];
+        genesParam.split(',').forEach(function(token) {
+          var id = parseInt(token);
+          if (!isNaN(id) && arr.indexOf(id) === -1) {
+            arr.push(id);
+          }
+        });
+        return arr;
+      };
+
+      var genesInURL = getGenesInURL($stateParams.genes);
       var genes = [];
       var edges = [];
 
-      /**
-       * Find index of input gene ID in genes array.
-       * @arg {int} gid Input gene's ID.
-       * @return {int} The index of gid, -1 if not found.
-       */
-      function findGeneIndex(gid) {
+      // Function that finds index of an input gene ID in "genes".
+      var findGeneIndex = function(gid) {
         for (var i = 0; i < genes.length; ++i) {
           if (genes[i].id === gid) {
             return i;
           }
         }
         return -1;
-      }
+      };
 
-      /**
-       * Update input edge and gene data.
-       * @param {edge} edgeIn;
-       * @param {gene} geneIn;
-       * @return {void}.
-       */
-      function updateData(edgeIn, geneIn) {
-        if (geneIn !== edgeIn.gene1 && geneIn !== edgeIn.gene2) {
-          return;
-        } // Do nothing if edgeIn and geneIn are not related.
-
-        var propertyName = (geneIn === edgeIn.gene1 ? 'source' : 'target');
-        var idx = findGeneIndex(geneIn.id);
-        if (idx === -1) {
-          if (urlGenes.indexOf(geneIn.id.toString()) !== -1) {
-            geneIn.query = true;
+      // Function that returns the list of genes that will be queried.
+      var getQueriedGenes = function(edgeList) {
+        // The genes that will be queried on the server should be determined
+        // by both genesInURL and edgeList, because even if a gene in the URL
+        // doesn't have any edge in the database, it still should be displayed
+        // in the network.
+        var geneList = genesInURL.slice(0); // Copy all genes ID in the URL.
+        // Collect unique gene IDs in edgeList.
+        edgeList.forEach(function(val) {
+          if (geneList.indexOf(val.gene1) === -1) {
+            geneList.push(val.gene1);
           }
-          geneIn.label = (geneIn.standard_name ? geneIn.standard_name
-                          : geneIn.systematic_name);
-          genes.push(geneIn);
-          idx = genes.length - 1;
+          if (geneList.indexOf(val.gene2) === -1) {
+            geneList.push(val.gene2);
+          }
+        });
+        return geneList;
+      };
+
+      // Function that sets genes in the network.
+      var setGenes = function(responseObject) {
+        genes = responseObject.objects;
+        genes.forEach(function(g) {
+          g.label = g.standard_name ? g.standard_name : g.systematic_name;
+          if (genesInURL.indexOf(g.id) !== -1) {
+            g.query = true;
+          }
+        });
+      };
+
+      // Function that sets edges in the netowrk.
+      var setEdges = function(edgeList) {
+        // Build a hash with gene objects indexed by pk.
+        var geneObjectHash = {};
+        genes.forEach(function(geneObj) {
+          geneObjectHash[geneObj.pk] = geneObj;
+        });
+        // Now we can process all edges
+        for (var i = 0, n = edgeList.length; i < n; ++i) {
+          var currEdge = edgeList[i];
+          currEdge.gene1 = geneObjectHash[currEdge.gene1]; // gene1
+          var idx = findGeneIndex(currEdge.gene1.id);
+          currEdge['source'] = idx;
+          currEdge.gene2 = geneObjectHash[currEdge.gene2]; // gene2
+          idx = findGeneIndex(currEdge.gene2.id);
+          currEdge['target'] = idx;
+          edges.push(currEdge); // Add current edge
         }
-        edgeIn[propertyName] = idx;
         // IMPORTANT implementation detail: d3.network library will reset
         // edge.source and edge.target to the gene object later, so the values
         // of "source" and "target" properties of the edge won't be integers
         // any more.
-      }
+      };
 
       /**
        * Draw gene-gene network.
@@ -242,7 +289,7 @@ angular.module('adage.gene.network', [
           htmlText += data.weight.toFixed(weightPrecision);
           var heavyGenes = [data.gene1.id, data.gene2.id].join(',');
           var target = d3.event.target;
-          NodeService.get(
+          Node.get(
             {'heavy_genes': heavyGenes, 'limit': 0},
             function success(response) {
               var i = 0, n = response.objects.length;
@@ -280,8 +327,14 @@ angular.module('adage.gene.network', [
         network.onGene('click.custom', showGeneTip);
         network.onEdge('click.custom', showEdgeTip);
 
-        // Draw network svg with legend.
-        network.showLegend();
+        // Draw network svg with edge and gene legend bars.
+        network.showEdgeLegend();
+        if (geneColored) {
+          // Function to set the color of gene circles in d3 network:
+          var setGeneColor = d3.scale.linear()
+              .domain([-1.0, 0, 1.0]).range(['blue', 'white', 'red']);
+          network.geneColor(setGeneColor).showGeneLegend();
+        }
         self.renderNetwork();
 
         // Add event handlers to gene-tip and edge-tip so that they will be
@@ -300,26 +353,114 @@ angular.module('adage.gene.network', [
         addClickHandler('edge-tip', edgeTip.hide);
       } // End of drawNetwork()
 
-      EdgeService.get(
+      Edge.get(
         {genes: $stateParams.genes, mlmodel: $stateParams.mlmodel, limit: 0},
         function success(responseObject) {
-          for (var i = 0, n = responseObject.objects.length; i < n; ++i) {
-            var currEdge = responseObject.objects[i];
-            updateData(currEdge, currEdge.gene1);
-            updateData(currEdge, currEdge.gene2);
-            edges.push(currEdge);
-          }
-          if (genes.length === 0) {
-            self.statusMessage = 'Gene(s) not found, please check the gene ID.';
-            return;
-          }
-          self.statusMessage = '';
-          drawNetwork();
+          var edgeList = responseObject.objects;
+          // Collect a list of distinct genes for query.
+          var geneList = getQueriedGenes(edgeList);
+          // Now retrieve the Gene objects using the geneList.
+          Gene.get({'pk__in': geneList.join(), 'limit': 0},
+            function success(responseObject) {
+              setGenes(responseObject);
+              if (genes.length === 0) {
+                self.statusMessage =
+                  'Gene(s) not found, please check the gene ID.';
+                return;
+              }
+              setEdges(edgeList);
+              // If genes in the network do not need to be colored, draw
+              // the network and we are done.
+              if (!geneColored) {
+                self.statusMessage = '';
+                drawNetwork();
+                return;
+              }
+              // If gene circles should be colored, calculate each gene's
+              // expression value difference between comp_group and base_group.
+              var baseSampleIDs = baseSamples.split(',');
+              baseSampleIDs = baseSampleIDs.map(function(x) {
+                return parseInt(x);
+              });
+              var compSampleIDs = compSamples.split(',');
+              compSampleIDs = compSampleIDs.map(function(x) {
+                return parseInt(x);
+              });
+
+              var sampleID = baseSampleIDs.concat(compSampleIDs);
+              var geneID = genes.map(function(g) {
+                return g.id;
+              });
+
+              ExpressionValue.get(
+                {'gene__in': geneID.join(), 'sample__in': sampleID.join(),
+                  'order_by': 'gene'},
+                function success(responseObject) {
+                  // Function that calculates input gene's expression value
+                  // based on the input array of base and comparison sums.
+                  var calcGeneExpr = function(geneID, exprTracker) {
+                    // Do nothing if the length of exprTracker is not 4, or one
+                    // of the two groups doesn't have any expression values.
+                    if (geneID === null || exprTracker.length !== 4 ||
+                        !exprTracker[1] || !exprTracker[3]) {
+                      return;
+                    }
+                    // Do nothing if input geneID is not found in genes.
+                    var geneIndex = findGeneIndex(geneID);
+                    if (geneIndex === -1) {
+                      return;
+                    }
+                    var baseAvg = exprTracker[0] / exprTracker[1];
+                    var compAvg = exprTracker[2] / exprTracker[3];
+                    genes[geneIndex].exprVal = compAvg - baseAvg;
+                  };
+
+                  var i = 0, n = responseObject.objects.length;
+                  var geneID = n > 0 ? responseObject.objects[0].gene : null;
+                  // exprTracker[0]: sum of expression values in base_group;
+                  // exprTracker[1]: # of expression values in base_group;
+                  // exprTracker[2]: sum of expression values in comp_group;
+                  // exprTracker[3]: # of expression values in comp_group;
+                  var exprTracker = [0, 0, 0, 0];
+                  for (; i < n; ++i) {
+                    var currObj = responseObject.objects[i];
+                    if (currObj.gene !== geneID) {  // reset exprTracker
+                      calcGeneExpr(geneID, exprTracker);
+                      geneID = currObj.gene;
+                      exprTracker = [0, 0, 0, 0];
+                    }
+                    // Current record belongs to base_group
+                    if (baseSampleIDs.indexOf(currObj.sample) !== -1) {
+                      exprTracker[0] += currObj.value;
+                      ++exprTracker[1];
+                    } else { // Current record belongs to comp_group
+                      exprTracker[2] += currObj.value;
+                      ++exprTracker[3];
+                    }
+                  }
+                  calcGeneExpr(geneID, exprTracker); // The last gene!
+                  self.statusMessage = '';
+                  drawNetwork();
+                },
+                function error(response) {
+                  var message = errGen('Failed to get gene expression value: ',
+                                       response);
+                  $log.error(message);
+                  self.statusMessage = message + '. Please try again later.';
+                }
+              );
+            },
+            function error(response) {
+              var message = errGen('Failed to get genes: ', response);
+              $log.error(message);
+              self.statusMessage = message + '. Please try again later.';
+            }
+          );
         },
         function error(response) {
           var message = errGen('Failed to get edges: ', response);
           $log.error(message);
-          self.statusMessage = message + '. Please try again later';
+          self.statusMessage = message + '. Please try again later.';
         }
       );
     }

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -172,7 +172,7 @@ angular.module('adage.gene.network', [
         // by both genesInURL and edgeList, because even if a gene in the URL
         // doesn't have any edge in the database, it still should be displayed
         // in the network.
-        var geneList = genesInURL.slice(0); // Copy all genes ID in the URL.
+        var geneList = genesInURL.slice(0); // Copy all gene IDs in the URL.
         // Collect unique gene IDs in edgeList.
         edgeList.forEach(function(val) {
           if (geneList.indexOf(val.gene1) === -1) {

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -172,7 +172,7 @@ angular.module('adage.gene.network', [
         // by both genesInURL and edgeList, because even if a gene in the URL
         // doesn't have any edge in the database, it still should be displayed
         // in the network.
-        var geneList = genesInURL.slice(0); // Copy all gene IDs in the URL.
+        var geneList = genesInURL.slice(0); // Copy all gene IDs from the URL.
         // Collect unique gene IDs in edgeList.
         edgeList.forEach(function(val) {
           if (geneList.indexOf(val.gene1) === -1) {

--- a/interface/src/app/gene/network/network.less
+++ b/interface/src/app/gene/network/network.less
@@ -5,7 +5,7 @@ line.edge {
 circle.gene {
   stroke-width: 2px;
   stroke: #AAA;
-  fill: #FFF;
+  //fill: #FFF;
 }
 circle.gene-query {
   stroke-width: 3px;

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -17,7 +17,6 @@
       Include positive correlation
     </label>
   </form>
-</div>
   <rzslider
      rz-slider-model="ctrl.slider.min"
      rz-slider-high="ctrl.slider.max"

--- a/interface/src/index.html
+++ b/interface/src/index.html
@@ -25,7 +25,7 @@
       FIXME: Ideally d3.network.js should be installed in vendor/ subdirectory,
       but since it is under active development, it is requested online for now.
       -->
-    <script src="https://rawgit.com/aaronkw/d3-network/master/d3.network.js"
+    <script src="https://rawgit.com/dongbohu/d3-network/master/d3.network.js"
             charset="utf-8"></script>
 
     <!-- it's stupid to have to load it here, but this is for the +1 button -->


### PR DESCRIPTION
This PR adds the functionality of coloring the gene circles in the network. It also integrates the code in PR #112 by @mhuyck.

Coding style may not be the best due to the upcoming deadline. For example, in lines 356-465 in `network.js`, it would be better to chain the three API calls instead of nesting them. I will address them after the deadline.

This PR also uses my own d3.network.js instead of Aaron Wang's.

Demo page:
http://165.123.67.202/#/gene_network/?genes=6547&base_group=123,124&comp_group=125,126 