### PR TITLE
Fix of issue #71: Highlight "GeneNetwork" tab when network is shown

### DIFF
--- a/interface/src/app/app.js
+++ b/interface/src/app/app.js
@@ -29,8 +29,9 @@ angular.module('adage', [
   $resourceProvider.defaults.stripTrailingSlashes = false;
 }])
 
-.controller('AppCtrl', ['$scope', 'UserFactory',
-  function AppCtrl($scope, UserFactory) {
+.controller('AppCtrl', ['$scope', '$state', 'UserFactory',
+  function AppCtrl($scope, $state, UserFactory) {
+    $scope.state = $state;
     $scope.$on('$stateChangeSuccess',
       function(event, toState, toParams, fromState, fromParams) {
         if (angular.isDefined(toState.data.pageTitle)) {

--- a/interface/src/app/app.js
+++ b/interface/src/app/app.js
@@ -31,7 +31,14 @@ angular.module('adage', [
 
 .controller('AppCtrl', ['$scope', '$state', 'UserFactory',
   function AppCtrl($scope, $state, UserFactory) {
-    $scope.state = $state;
+    // Function that indicates whether the current state is 'gene_search'
+    // or 'gene_network'. It will be used in index.html to highlight the
+    // 'GeneNetwork' tab on web UI in either state.
+    $scope.inGeneStates = function() {
+      var currState = $state.current.name;
+      return currState === 'gene_search' || currState === 'gene_network';
+    };
+
     $scope.$on('$stateChangeSuccess',
       function(event, toState, toParams, fromState, fromParams) {
         if (angular.isDefined(toState.data.pageTitle)) {

--- a/interface/src/index.html
+++ b/interface/src/index.html
@@ -77,7 +77,9 @@
                 Download
               </a>
             </li>
-            <li ui-sref-active="active">
+            <li ng-class="{active:
+                          state.current.name.indexOf('gene_search') !== -1 ||
+                          state.current.name.indexOf('gene_network') !== -1}">
               <a ui-sref="gene_search">
                 GeneNetwork
               </a>

--- a/interface/src/index.html
+++ b/interface/src/index.html
@@ -78,8 +78,8 @@
               </a>
             </li>
             <li ng-class="{active:
-                          state.current.name.indexOf('gene_search') !== -1 ||
-                          state.current.name.indexOf('gene_network') !== -1}">
+                          state.current.name === 'gene_search' ||
+                          state.current.name === 'gene_network'}">
               <a ui-sref="gene_search">
                 GeneNetwork
               </a>

--- a/interface/src/index.html
+++ b/interface/src/index.html
@@ -77,9 +77,7 @@
                 Download
               </a>
             </li>
-            <li ng-class="{active:
-                          state.current.name === 'gene_search' ||
-                          state.current.name === 'gene_network'}">
+            <li ng-class="{active: inGeneStates()}">
               <a ui-sref="gene_search">
                 GeneNetwork
               </a>


### PR DESCRIPTION
This is a fix of issue #71. 

There are a few ways to solve this problem. The one I chose is the simplest but may not be the best. According to the ui-router doc, the best seems to be create a parent state of `gene`, then make `gene_search` and `gene_network` the child states. But that will change at least three files, so I chose the current approach. I think it is a good hack to know.