### PR TITLE
Fix of Issues #130 and #83

### DIFF
--- a/adage/requirements.txt
+++ b/adage/requirements.txt
@@ -10,7 +10,7 @@ python-dateutil==2.5.0
 python-mimeparse==1.5.1
 six==1.10.0
 unicodecsv==0.14.1
-urllib3==1.14
+urllib3==1.21.1
 wsgiref==0.1.2
 django-genes>=0.11
 tribe-client>=1.1.8

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -12,12 +12,6 @@ angular.module('adage.analyze.sampleBin', [
   'adage.signature.resources'
 ])
 
-.factory('Activity', ['$resource', 'ApiBasePath',
-  function($resource, ApiBasePath) {
-    return $resource(ApiBasePath + 'activity/');
-  }
-])
-
 .factory('SignatureSet', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
     return $resource(ApiBasePath + 'node/set/:ids/');

--- a/interface/src/app/sample_annotation/annotation.js
+++ b/interface/src/app/sample_annotation/annotation.js
@@ -5,8 +5,8 @@
 angular.module('adage.sampleAnnotation', [
   'ui.router',
   'ui.bootstrap',
-  'ngResource',
   'adage.utils',
+  'adage.signature.resources',
   'adage.sample.services'
 ])
 
@@ -22,12 +22,6 @@ angular.module('adage.sampleAnnotation', [
     data: {pageTitle: 'Sample Annotations'}
   });
 }])
-
-.factory('Activity', ['$resource', 'ApiBasePath',
-  function($resource, ApiBasePath) {
-    return $resource(ApiBasePath + 'activity');
-  }
-])
 
 .controller('SampleAnnotationCtrl', [
   '$stateParams', '$q', '$log', 'errGen', 'Activity', 'Sample',
@@ -101,6 +95,7 @@ angular.module('adage.sampleAnnotation', [
               sampleDict[element.id] = {};
             }
             sampleDict[element.id].name = element.name;
+            sampleDict[element.id].dataSource = element.ml_data_source;
             sampleDict[element.id].annotations = element.annotations;
             var currentTypes = Object.keys(element.annotations);
             currentTypes.forEach(function(annotationType) {

--- a/interface/src/app/sample_annotation/annotation.tpl.html
+++ b/interface/src/app/sample_annotation/annotation.tpl.html
@@ -7,6 +7,7 @@
   <thead>
     <th ng-if="ctrl.hasSignature">Activity</th>
     <th>Sample Name</th>
+    <th>Data Source</th>
     <th ng-repeat="typeName in ctrl.uniqueAnnotationTypes">
       {{typeName}}
     </th>
@@ -19,6 +20,7 @@
         <strong>{{sample.activity | number: ctrl.activityDigits}}</strong>
       </td>
       <td>{{sample.name}}</td>
+      <td>{{sample.dataSource}}</td>
       <td ng-repeat="typeName in ctrl.uniqueAnnotationTypes">
         {{sample.annotations[typeName] ? sample.annotations[typeName] : ""}}
       </td>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -8,10 +8,7 @@
           ng-show="topMode">Show All</button>
 
   <br>
-  (Click
-  <i class="fa fa-plus-square fa-lg" aria-hidden="true"></i> or
-  <i class="fa fa-minus-square fa-lg" aria-hidden="true"></i>
-  to show or hide the samples related to both the signature and experiment.)
+  (Click the activity graph to see annotations of samples in this experiement.)
   <table class="table table-striped">
     <tbody>
       <!-- It may seem more intuitive to use:
@@ -21,52 +18,14 @@
          -->
       <tr ng-repeat="exp in experiments" ng-show="$index < numExpShown">
         <td>
-          <i class="fa fa-plus-square fa-lg" aria-hidden="true"
-             ng-show="!exp.isExpanded" ng-click="toggleExpansion(exp)"></i>
-          <i class="fa fa-minus-square fa-lg" aria-hidden="true"
-             ng-show="exp.isExpanded" ng-click="toggleExpansion(exp)"></i>
           <b>{{$index + 1}}. {{exp.accession}}: </b>{{exp.name}}
-
-          <!-- Location of vega-lite widget -->
-          <div id="{{ 'exp-' + $index }}"></div>
-
-          <div ng-if="exp.isExpanded">
-            <div ng-if="!exp.sampleStatus">
-              <table class="table table-bordered table-condensed table-hover">
-                <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>Activity</th>
-                    <th>Sample Name</th>
-                    <th>Data Source</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr ng-repeat="sample in exp.samples | orderBy: '-activity'"
-                      ng-class="{success: sample.selected}">
-                    <td>
-                      <label>
-                        <input type="checkbox" ng-model="sample.selected"
-                               ng-change="toggleSelection(exp, sample.selected)">
-                        {{$index + 1}}
-                      </label>
-                    </td>
-                    <td>{{sample.activity | number: activityDigits}}</td>
-                    <td>{{sample.name}}</td>
-                    <td>{{sample.ml_data_source}}</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div style="text-align: center">
-                <button class="btn btn-md btn-success"
-                        ng-disabled="exp.numSelections === 0"
-                        ng-click="showAnnotations(exp)">
-                  Show Annotations of Selected Samples
-                </button>
-              </div>
-            </div>
-            <div ng-bind="exp.sampleStatus"></div>
-          </div>
+          <!-- vega-lite widget. If it is clicked, go to sample annotations
+               page. -->
+          <a ui-sref="sampleAnnotation(
+                      {signature: signatureId, samples: exp.sample_set.join()}
+                      )">
+            <div id="{{ 'exp-' + $index }}"></div>
+          </a>
         </td>
       </tr>
     </tbody>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -8,7 +8,7 @@
           ng-show="topMode">Show All</button>
 
   <br>
-  (Click the activity graph to see annotations of samples in this experiement.)
+  (Click the activity distribution widget to see sample annotations in this experiement.)
   <table class="table table-striped">
     <tbody>
       <!-- It may seem more intuitive to use:
@@ -24,7 +24,10 @@
           <a ui-sref="sampleAnnotation(
                       {signature: signatureId, samples: exp.sample_set.join()}
                       )">
-            <div id="{{ 'exp-' + $index }}"></div>
+            <div id="{{ 'exp-' + $index }}"
+                 uib-tooltip-html="'<b>Click to see sample annotations</b>'"
+                 tooltip-placement="left-top">
+            </div>
           </a>
         </td>
       </tr>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -24,6 +24,13 @@
           <a ui-sref="sampleAnnotation(
                       {signature: signatureId, samples: exp.sample_set.join()}
                       )">
+            <!-- The UI would look nicer if the tooltip showed up on the right
+                 side of the activity distribution map (instead of left side).
+                 But because the vega-lite widget takes the full width of the
+                 area, if we had set tooltip-placement to "right" or
+                 "right-top", the tooltip would have shown up way beyond the
+                 right border. So tooltip-placement is set to "left-top" here.
+              -->
             <div id="{{ 'exp-' + $index }}"
                  uib-tooltip-html="'<b>Click to see sample annotations</b>'"
                  tooltip-placement="left-top">

--- a/interface/src/app/signature/resources.js
+++ b/interface/src/app/signature/resources.js
@@ -13,6 +13,19 @@ angular.module('adage.signature.resources', [
 
 .factory('Participation', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
-    return $resource(ApiBasePath + 'participation/');
+    return $resource(ApiBasePath + 'participation');
   }
-]);
+])
+
+.factory('Activity', ['$resource', 'ApiBasePath',
+  function($resource, ApiBasePath) {
+    return $resource(ApiBasePath + 'activity');
+  }
+])
+
+.factory('Experiment', ['$resource', 'ApiBasePath',
+  function($resource, ApiBasePath) {
+    return $resource(ApiBasePath + 'experiment');
+  }
+])
+;

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -92,8 +92,71 @@ angular.module('adage.signature', [
   }]
 )
 
-.directive('highRangeExp', ['$http', '$log', '$state', 'ActivityDigits',
-  function($http, $log, $state, ActivityDigits) {
+// A service that defines the specifications of embedded vega-lite widget.
+// It is used by "highRangeExp" directive.
+.service('EmbedSpecService', [function() {
+  // sample2index: a dictionary that maps a sample's ID to the index
+  // of this sample's activity value in "EmbedSpecService.spec.data.values".
+  // It will make the toggling of "highlight" flag faster.
+  sample2index = {};
+
+  this.mode = 'vega-lite';
+  this.actions = false;
+  // Method that sets vega-lite specification:
+  this.setSpec = function(activities) {
+    var activityArr = [];
+    var samples = Object.keys(activities);
+    samples.forEach(function(sampleID, index) {
+      activityArr.push({
+        'val': activities[sampleID],
+        'highlight': false
+      });
+      sample2index[sampleID] = index;
+    });
+
+    var vlSpec = {
+      'data': {values: activityArr},
+      'mark': 'tick',
+      'encoding': {
+        'x': {
+          'field': 'val',
+          'type': 'quantitative',
+          'axis': {
+            'grid': false,
+            'title': '',
+            'format': 'r'
+          }
+        },
+        'color': {
+          'field': 'highlight',
+          'type': 'nominal',
+          'scale': {'range': ['black', 'red']},
+          'legend': false
+        },
+        'size': {
+          'field': 'highlight',
+          'type': 'nominal',
+          'scale': {'range': [10, 30]},
+          'legend': false
+        }
+      }
+    };
+    this.spec = vlSpec;
+  };
+
+  // Method that toggles "highlight" flags based on input sample IDs:
+  this.toggleLines = function(samples) {
+    for (var i = 0; i < samples.length; ++i) {
+      var arrIndex = sample2index[samples[i]];
+      var val = this.spec.data.values[arrIndex].highlight;
+      this.spec.data.values[arrIndex].highlight = !val;
+    }
+  };
+}])
+
+.directive('highRangeExp', ['Activity', 'Experiment', 'EmbedSpecService',
+  'errGen', '$log',
+  function(Activity, Experiment, EmbedSpecService, errGen, $log) {
     return {
       templateUrl: 'signature/high_range_exp.tpl.html',
       restrict: 'E',
@@ -104,7 +167,6 @@ angular.module('adage.signature', [
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';
         $scope.activities = {};
-        $scope.activityDigits = ActivityDigits;
         $scope.experiments = [];
         $scope.topMode = true;
         // If "top-exp" tag is not found, or its value is not a finite positive
@@ -127,210 +189,100 @@ angular.module('adage.signature', [
         $scope.numExpShown = $scope.topNum;
 
         // Get activities that are related to the current signature:
-        var httpConfig = {params: {node: $scope.signatureId, limit: 0}};
-        $http.get('/api/v0/activity/', httpConfig)
-          .then(function success(response) {
-            var sampleID;
-            for (var i = 0; i < response.data.objects.length; ++i) {
-              sampleID = response.data.objects[i].sample;
-              $scope.activities[sampleID] = response.data.objects[i].value;
-            }
-            return $http.get('/api/v0/experiment/', httpConfig);
-          }, function error(err) {
-            $log.error('Failed to get activities: ' + err.statusText);
-            $scope.queryStatus = 'Failed to get related activities from server';
-          })
-          // Get experiments that are related to the current signature:
-          .then(function success(response) {
-            // enhanceExpData: a function that enhances the given experiment.
-            // The enhancements include:
-            // (1) Add a new key "isExpanded", whose default is false;
-            // (2) Convert entries in sample_set from sample URI to sample ID,
-            //     and delete samples that are not related to current signature;
-            // (3) Add a new "range" key, which is the range of activity values.
-            //     (This key will be used to order experiments on web UI.)
-            var enhanceExpData = function(exp) {
-              exp.isExpanded = false;  // Enhancement (1)
-              var signatureRelatedSamples = [];
-              exp.sample_set.forEach(function(element) { // Enhancement (2)
-                var parts = element.split('/');
-                // The format of exp.sample_set[i] is "/api/v0/sample/1234/",
-                // so after the split, "parts" will always include 6 entries:
-                // ["", "api", "v0", "sample", "1234", ""]
-                var sampleID = parts[parts.length - 2];
-                if (sampleID in $scope.activities) {
-                  signatureRelatedSamples.push(sampleID);
-                }
-              });
-              exp['sample_set'] = signatureRelatedSamples;
-              // Enhancement (3): Add activity range
-              var minActivity = null;
-              var maxActivity = null;
-              var sampleID, currValue;
-              for (var i = 0, n = exp.sample_set.length; i < n; ++i) {
-                sampleID = exp.sample_set[i];
-                currValue = $scope.activities[sampleID];
-                if (!minActivity || minActivity > currValue) {
-                  minActivity = currValue;
-                }
-                if (!maxActivity || maxActivity < currValue) {
-                  maxActivity = currValue;
-                }
-              }
-              exp.range = maxActivity - minActivity;
-            }; // end of enhanceExpData() definition.
+        var activityPromise = Activity.get(
+          {node: $scope.signatureId, limit: 0}
+        ).$promise;
 
-            // setEmbedSpec: a function that sets the specification for
-            // vega-lite. The second parameter "sample2index" maps a sample's ID
-            // to the index of this sample in activityArr to make the toggling
-            // of "highlight" flag faster.
-            var setEmbedSpec = function(embedSpec, sample2index) {
-              var activityArr = [];
-              var samples = Object.keys($scope.activities);
-              for (var i = 0; i < samples.length; ++i) {
-                activityArr.push({
-                  'val': $scope.activities[samples[i]],
-                  'highlight': false
-                });
-                sample2index[samples[i]] = i;
+        // Function that will be called to handle experiment data
+        var handleExperimentResponse = function(response) {
+          // enhanceExpData: a function that enhances the given experiment.
+          // The enhancements include:
+          // (1) Convert entries in sample_set from sample URI to sample ID,
+          //     and delete samples that are not related to current signature;
+          // (2) Add a new "range" property, which is the range of activity
+          //     values, which will be used to order experiments on web UI.
+          var enhanceExpData = function(exp) {
+            var signatureRelatedSamples = [];
+            exp.sample_set.forEach(function(element) { // Enhancement (1)
+              var tokens = element.split('/');
+              // The format of exp.sample_set[i] is "/api/v<n>/sample/1234/",
+              // so after the split, "tokens" will always include 6 entries:
+              // ["", "api", "v<n>", "sample", "1234", ""]
+              var sampleID = tokens[tokens.length - 2];
+              if (sampleID in $scope.activities) {
+                signatureRelatedSamples.push(sampleID);
               }
-              var vlSpec = {
-                'data': {values: activityArr},
-                'mark': 'tick',
-                'encoding': {
-                  'x': {
-                    'field': 'val',
-                    'type': 'quantitative',
-                    'axis': {
-                      'grid': false,
-                      'title': '',
-                      'format': 'r'
-                    }
-                  },
-                  'color': {
-                    'field': 'highlight',
-                    'type': 'nominal',
-                    'scale': {'range': ['black', 'red']},
-                    'legend': false
-                  },
-                  'size': {
-                    'field': 'highlight',
-                    'type': 'nominal',
-                    'scale': {'range': [10, 30]},
-                    'legend': false
-                  }
-                }
-              };
-              embedSpec.spec = vlSpec;
-            }; // end of setEmbedSpec() definition.
-
-            // Enhance experiment objects and put them into $scope.experiments.
-            response.data.objects.forEach(function(element) {
-              enhanceExpData(element);
-              $scope.experiments.push(element);
             });
-            // Sort experiments by range in descending order:
-            $scope.experiments.sort(function(e1, e2) {
-              return e2.range - e1.range;
-            });
-
-            // Add vega-lite widget for each experiment:
-            var embedSpec = {'mode': 'vega-lite', 'actions': false};
-            var sample2index = {};
-
-            // toggleSampleHighlights(): a function that toggles "highlight"
-            // flag of samples in an experiment:
-            var toggleSampleHighlights = function(expIndex) {
-              var currExp = $scope.experiments[expIndex];
-              var j, sid, arrIndex, val;
-              for (j = 0; j < currExp.sample_set.length; ++j) {
-                sid = $scope.experiments[i].sample_set[j];
-                arrIndex = sample2index[sid];
-                val = embedSpec.spec.data.values[arrIndex].highlight;
-                embedSpec.spec.data.values[arrIndex].highlight = !val;
+            exp['sample_set'] = signatureRelatedSamples;
+            // Enhancement (2): Add activity range
+            var minActivity = null;
+            var maxActivity = null;
+            var sampleID, currValue;
+            for (var i = 0, n = exp.sample_set.length; i < n; ++i) {
+              sampleID = exp.sample_set[i];
+              currValue = $scope.activities[sampleID];
+              if (minActivity === null || minActivity > currValue) {
+                minActivity = currValue;
               }
-            };
-            setEmbedSpec(embedSpec, sample2index); // Initialize embedSpec.
-            // For each experiment, toggle the highlight flags (to true) for
-            // all of its samples, embed the vega-lite widget, and toggle these
-            // highlight flags again (to false). This procedure ensures that
-            // only activitity values in current experiment will be highlighted
-            // in the widget.
-            for (var i = 0, n = $scope.experiments.length; i < n; ++i) {
-              toggleSampleHighlights(i);
-              vg.embed('#exp-' + i, embedSpec, function(error, result) { });
-              toggleSampleHighlights(i);
+              if (maxActivity === null || maxActivity < currValue) {
+                maxActivity = currValue;
+              }
             }
-            // Clear $scope.queryStatus to indicate that the view is ready!
-            $scope.queryStatus = '';
-          }, function error(err) {
-            $log.error('Failed to get activities: ' + err.statusText);
-            $scope.queryStatus =
-              'Failed to get related experiments from server';
-          }); // end of $http.get().then().then() chaining.
+            exp.range = maxActivity - minActivity;
+          };
 
-        // Event handler when user clicks "+" or "-" icon in front of
-        // an experiment.
-        $scope.toggleExpansion = function(exp) {
-          exp.isExpanded = !exp.isExpanded;
-          // Get samples data if they are not available yet.
-          if (exp.isExpanded && !exp.samples) {
-            exp.sampleStatus = 'Connecting to the server ...';
-            var sampleURI = '/api/v0/sample/';
-            $http.get(sampleURI, {params: {experiment: exp.accession}})
-              .then(function success(response) {
-                exp.samples = [];
-                exp.numSelections = 0;
-                // Add "activity" property to each sample that is related to the
-                // current signature (to order samples on web UI later).
-                response.data.objects.forEach(function(element) {
-                  if (element.id in $scope.activities) {
-                    element.activity = $scope.activities[element.id];
-                    element.selected = false; // default: sample not selected.
-                    exp.samples.push(element);
-                  }
-                });
-                exp.sampleStatus = '';
-              }, function error(err) {
-                $log.error('Failed to get sample data: ' + err.statusText);
-                exp.sampleStatus = 'Failed to get sample data from ' +
-                  sampleURI;
-              }
-            );
-          }
+          // Enhance experiment objects and put them into $scope.experiments.
+          response.objects.forEach(function(element) {
+            enhanceExpData(element);
+            $scope.experiments.push(element);
+          });
+          // Sort experiments by range in descending order:
+          $scope.experiments.sort(function(e1, e2) {
+            return e2.range - e1.range;
+          });
+          // Add vega-lite widget for each experiment:
+          EmbedSpecService.setSpec($scope.activities);
+          $scope.experiments.forEach(function(exp, index) {
+            EmbedSpecService.toggleLines(exp.sample_set);
+            vg.embed('#exp-' + index, EmbedSpecService);
+            EmbedSpecService.toggleLines(exp.sample_set);
+          });
+          // Indicate that the view is ready!
+          $scope.queryStatus = '';
         };
+
+        // Handle activities that are releted to the current signature.
+        activityPromise.then(
+          function success(response) {
+            var sampleID;
+            for (var i = 0; i < response.objects.length; ++i) {
+              sampleID = response.objects[i].sample;
+              $scope.activities[sampleID] = response.objects[i].value;
+            }
+            return Experiment.get({node: $scope.signatureId, limit: 0})
+              .$promise;
+          },
+          function error(response) {
+            var errMessage = errGen('Failed to get activities', response);
+            $log.error(errMessage);
+            $scope.queryStatus = errMessage + '. Please try again later.';
+          }
+        )
+        // Handle experiments that are related to the current signature.
+        .then(
+          handleExperimentResponse,
+          function error(response) {
+            var errMessage = errGen('Failed to get experiments', response);
+            $log.error(errMessage);
+            $scope.queryStatus = errMessage + '. Please try again later.';
+          }
+        );
 
         // Event handler when user clicks "Show All" or "Show Top N" button.
         $scope.setMode = function() {
           $scope.topMode = !$scope.topMode;
           $scope.numExpShown =
             $scope.topMode ? $scope.topNum : $scope.experiments.length;
-        };
-
-        // Event handler when user clicks the checkbox in front of each sample.
-        // It keeps track of the number of selected samples in each experiment
-        // to indicate whether the "show annotations" button should be enabled.
-        $scope.toggleSelection = function(exp, selected) {
-          if (selected) {
-            ++exp.numSelections;
-          } else {
-            --exp.numSelections;
-          }
-        };
-
-        // Event handler when user clicks the "show annotations" button:
-        $scope.showAnnotations = function(exp) {
-          var selectedSampleIDs = [];
-          exp.samples.forEach(function(sample) {
-            if (sample.selected) {
-              selectedSampleIDs.push(sample.id);
-            }
-          });
-          var stateParams = {
-            signature: $scope.signatureId,
-            samples: selectedSampleIDs.join()
-          };
-          $state.go('sampleAnnotation', stateParams);
         };
       } // end of link function
     };
@@ -364,7 +316,7 @@ angular.module('adage.signature', [
 
         // This is the main function that calculates the geneset enrichments.
         // It calculates the enrichment for each geneset that has genes
-        // also present in the signature high weight genes, and pushes that
+        // also present in the signature's high weight genes, and pushes that
         // geneset into the releventGenesetArray.
         var calculateEnrichments = function(geneGenesets, allGenesetInfo,
                                             totalGeneNum, cutoff) {

--- a/interface/src/app/signature/signature.spec.js
+++ b/interface/src/app/signature/signature.spec.js
@@ -109,8 +109,8 @@ describe('<high-range-exp> directive', function() {
       ' top-exp="{{topExp}}"></high-range-exp>';
 
     element = $compile(testHTML)(parentScope);
-    activityUri = '/api/v0/activity/?limit=0&node=' + parentScope.signatureID;
-    experimentUri = '/api/v0/experiment/?limit=0&node=' +
+    activityUri = '/api/v0/activity?limit=0&node=' + parentScope.signatureID;
+    experimentUri = '/api/v0/experiment?limit=0&node=' +
       parentScope.signatureID;
 
     mockExperiment = [{
@@ -153,27 +153,27 @@ describe('<high-range-exp> directive', function() {
   it('should get the appropriate activity values', function() {
     // Mocked activity response data:
     var mockActivity = [
-      {id: 1, signature: 123, sample: 1001, value: 0.0854334209211516},
-      {id: 2, signature: 123, sample: 1002, value: 0.0689115612702348},
-      {id: 3, signature: 123, sample: 1003, value: 0.0702073433150119},
-      {id: 4, signature: 123, sample: 1004, value: 0.0677049302827924},
-      {id: 5, signature: 123, sample: 1005, value: 0.0712094377832054},
-      {id: 6, signature: 123, sample: 1006, value: 0.0721038265557411},
-      {id: 7, signature: 123, sample: 1007, value: 0.0715914344928831},
-      {id: 8, signature: 123, sample: 1008, value: 0.0825894283807123},
-      {id: 9, signature: 123, sample: 1009, value: 0.0836206569872482},
-      {id: 10, signature: 123, sample: 1010, value: 0.0647705496729518},
-      {id: 11, signature: 123, sample: 1011, value: 0.0658942367538415},
-      {id: 12, signature: 123, sample: 1012, value: 0.0727115753936357},
-      {id: 13, signature: 123, sample: 1013, value: 0.0790896289324697},
-      {id: 14, signature: 123, sample: 1014, value: 0.0692046195604449},
-      {id: 15, signature: 123, sample: 1015, value: 0.078560557941843},
-      {id: 16, signature: 123, sample: 1016, value: 0.0743736434104904},
-      {id: 17, signature: 123, sample: 1017, value: 0.07871175918013},
-      {id: 18, signature: 123, sample: 1018, value: 0.0614160606502279},
-      {id: 19, signature: 123, sample: 1019, value: 0.0661371872868119},
-      {id: 20, signature: 123, sample: 1020, value: 0.0783672660119669},
-      {id: 21, signature: 123, sample: 1021, value: 0.0769023791604038}
+      {id: 1, node: 123, sample: 1001, value: 0.0854334209211516},
+      {id: 2, node: 123, sample: 1002, value: 0.0689115612702348},
+      {id: 3, node: 123, sample: 1003, value: 0.0702073433150119},
+      {id: 4, node: 123, sample: 1004, value: 0.0677049302827924},
+      {id: 5, node: 123, sample: 1005, value: 0.0712094377832054},
+      {id: 6, node: 123, sample: 1006, value: 0.0721038265557411},
+      {id: 7, node: 123, sample: 1007, value: 0.0715914344928831},
+      {id: 8, node: 123, sample: 1008, value: 0.0825894283807123},
+      {id: 9, node: 123, sample: 1009, value: 0.0836206569872482},
+      {id: 10, node: 123, sample: 1010, value: 0.0647705496729518},
+      {id: 11, node: 123, sample: 1011, value: 0.0658942367538415},
+      {id: 12, node: 123, sample: 1012, value: 0.0727115753936357},
+      {id: 13, node: 123, sample: 1013, value: 0.0790896289324697},
+      {id: 14, node: 123, sample: 1014, value: 0.0692046195604449},
+      {id: 15, node: 123, sample: 1015, value: 0.078560557941843},
+      {id: 16, node: 123, sample: 1016, value: 0.0743736434104904},
+      {id: 17, node: 123, sample: 1017, value: 0.07871175918013},
+      {id: 18, node: 123, sample: 1018, value: 0.0614160606502279},
+      {id: 19, node: 123, sample: 1019, value: 0.0661371872868119},
+      {id: 20, node: 123, sample: 1020, value: 0.0783672660119669},
+      {id: 21, node: 123, sample: 1021, value: 0.0769023791604038}
     ];
 
     $httpBackend.expectGET(activityUri).respond({objects: mockActivity});


### PR DESCRIPTION
This PR is filed to fix issue #130 (and #83 as a byproduct) in **Signature** (aka. Node) page. I touched more code than expected:

1. Removed the samples in each experiment.

2. Made the vega-lite plot clickable. When it is clicked, the page will go to annotations of ALL samples in current experiment.

3. Refactored all resource classes into `resources.js`.

4. Used `$resource` to replace `$http` service.

5. Moved the code of vega-lite specification out of `highRangeExp` directive, and created a new service *EmbedSpecService* for it. It makes the code more readable.

6. Added "data_source" field in sample annotations web UI.

7. Removed redundant resource class in `sampleBin.js`, which refers to `signature/resources.js`.

8. Tweaked the API paths in signature module's test cases.