### PR TITLE
Workflow Redesign

### DIFF
--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -1,8 +1,8 @@
 <div class="page-header">
   <h1>About ADAGE</h1>
 </div>
-<h3>
-  <p>
+
+<h4>
     The ADAGE webserver allows users without programming expertise to analyze
     signatures extracted from large compendia of gene expression data via
     unsupervised machine learning methods. We primarily designed the server to
@@ -12,10 +12,12 @@
     <a href="http://biorxiv.org/content/early/2017/04/10/078659">eADAGE</a>;
     however, the server was designed to be general and can be used for other
     types of machine learning models as well.
-  <!--
-  <p>
+</h4>
+
+<!--
+<h4>
     If you use the server for any type of model, please cite the
     [ADAGE Signature Analysis paper](Link TBD). Please also cite the paper that
     reports the machine learning model that you use.
-    -->
-</h3>
+</h4>
+-->

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -2,7 +2,7 @@
   <h3>About ADAGE</h3>
 </div>
 
-<p>
+<p class="h4">
   The <strong>ADAGE</strong> (<strong>A</strong>nalysis using
   <strong>D</strong>enoising <strong>A</strong>utoencoders of
   <strong>G</strong>ene <strong>E</strong>xpression) web server allows users
@@ -18,8 +18,8 @@
 
 <!--
 <p>
-    If you use the server for any type of model, please cite the
-    [ADAGE Signature Analysis paper](Link TBD). Please also cite the paper that
-    reports the machine learning model that you use.
+  If you use the server for any type of model, please cite the
+  [ADAGE Signature Analysis paper](Link TBD). Please also cite the paper that
+  reports the machine learning model that you use.
 </p>
 -->

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -1,8 +1,6 @@
-<div>
-  <h1 class="page-header">
-    About ADAGE
-  </h1>
-  <p>
-    This is where some explanatory text about ADAGE should go.
-  </p>
+<div class="page-header">
+  <h1>About ADAGE</h1>
 </div>
+<p>
+  This is where some explanatory text about ADAGE should go.
+</p>

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -1,6 +1,21 @@
 <div class="page-header">
   <h1>About ADAGE</h1>
 </div>
-<p>
-  This is where some explanatory text about ADAGE should go.
-</p>
+<h3>
+  <p>
+    The ADAGE webserver allows users without programming expertise to analyze
+    signatures extracted from large compendia of gene expression data via
+    unsupervised machine learning methods. We primarily designed the server to
+    support models constructed by
+    <a href="http://msystems.asm.org/content/1/1/e00025-15">ADAGE</a>
+    and
+    <a href="http://biorxiv.org/content/early/2017/04/10/078659">eADAGE</a>;
+    however, the server was designed to be general and can be used for other
+    types of machine learning models as well.
+  <!--
+  <p>
+    If you use the server for any type of model, please cite the
+    [ADAGE Signature Analysis paper](Link TBD). Please also cite the paper that
+    reports the machine learning model that you use.
+    -->
+</h3>

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -1,8 +1,8 @@
 <div class="page-header">
-  <h1>About ADAGE</h1>
+  <h3>About ADAGE</h3>
 </div>
 
-<h4>
+<p>
     The ADAGE webserver allows users without programming expertise to analyze
     signatures extracted from large compendia of gene expression data via
     unsupervised machine learning methods. We primarily designed the server to
@@ -12,12 +12,12 @@
     <a href="http://biorxiv.org/content/early/2017/04/10/078659">eADAGE</a>;
     however, the server was designed to be general and can be used for other
     types of machine learning models as well.
-</h4>
+</p>
 
 <!--
-<h4>
+<p>
     If you use the server for any type of model, please cite the
     [ADAGE Signature Analysis paper](Link TBD). Please also cite the paper that
     reports the machine learning model that you use.
-</h4>
+</p>
 -->

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -3,15 +3,17 @@
 </div>
 
 <p>
-    The ADAGE webserver allows users without programming expertise to analyze
-    signatures extracted from large compendia of gene expression data via
-    unsupervised machine learning methods. We primarily designed the server to
-    support models constructed by
-    <a href="http://msystems.asm.org/content/1/1/e00025-15">ADAGE</a>
-    and
-    <a href="http://biorxiv.org/content/early/2017/04/10/078659">eADAGE</a>;
-    however, the server was designed to be general and can be used for other
-    types of machine learning models as well.
+  The <strong>ADAGE</strong> (<strong>A</strong>nalysis using
+  <strong>D</strong>enoising <strong>A</strong>utoencoders of
+  <strong>G</strong>ene <strong>E</strong>xpression) web server allows users
+  without programming expertise to analyze signatures extracted from large
+  compendia of gene expression data via unsupervised machine learning methods.
+  We primarily designed the server to support models constructed by
+  <a href="http://msystems.asm.org/content/1/1/e00025-15">ADAGE</a>
+  and
+  <a href="http://biorxiv.org/content/early/2017/04/10/078659">eADAGE</a>;
+  however, the server was designed to be general and can be used for other
+  types of machine learning models as well.
 </p>
 
 <!--

--- a/interface/src/app/analyze/analysis/analysis.js
+++ b/interface/src/app/analyze/analysis/analysis.js
@@ -15,7 +15,7 @@ angular.module('adage.analyze.analysis', [
 
 .config(['$stateProvider', function($stateProvider) {
   $stateProvider.state('analysis-detail', {
-    url: '/analysis-detail',
+    url: '/analysis-detail?mlmodel',
     views: {
       main: {
         controller: 'AnalysisCtrl',
@@ -26,8 +26,18 @@ angular.module('adage.analyze.analysis', [
   });
 }])
 
-.controller('AnalysisCtrl', ['$scope', '$log', '$q', '$state', 'SampleBin',
-function AnalysisCtrl($scope, $log, $q, $state, SampleBin) {
+.controller('AnalysisCtrl', ['$scope', '$log', '$q', '$state', '$stateParams',
+  'SampleBin',
+function AnalysisCtrl($scope, $log, $q, $state, $stateParams, SampleBin) {
+  $scope.isValidModel = false;
+  // Do nothing if mlmodel in URL is falsey. The error will be taken
+  // care of by "<ml-model-validator>" component.
+  if (!$stateParams.mlmodel) {
+    return;
+  }
+
+  $scope.modelInUrl = $stateParams.mlmodel;
+  SampleBin.getActivityForSampleList($scope.modelInUrl);
   $scope.analysis = {
     status: '',
     // TODO these exampleCols are temporarily hard-coded until a column chooser
@@ -38,12 +48,7 @@ function AnalysisCtrl($scope, $log, $q, $state, SampleBin) {
       {'typename': 'medium'},
       {'typename': 'temperature'},
       {'typename': 'treatment'}
-    ],
-    updateMlModel: function(value) {
-      if (value !== null && value.id !== null) {
-        SampleBin.getActivityForSampleList(value.id);
-      }
-    }
+    ]
   };
 
   // give our templates a way to access the SampleBin service
@@ -58,11 +63,7 @@ function AnalysisCtrl($scope, $log, $q, $state, SampleBin) {
   };
 
   $scope.showVolcanoPlot = function() {
-    if (SampleBin.selectedMlModel.id === null) {
-      $scope.analysis.status = 'Please select a machine learning model.';
-      return;
-    }
-    $state.go('volcano', {'mlmodel': SampleBin.selectedMlModel.id});
+    $state.go('volcano', {'mlmodel': $scope.modelInUrl});
   };
 
   // these options are important for making ngSortable work with tables

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -15,59 +15,60 @@
 
 <div ng-if="isValidModel">
 
-<status-bar msg-text="analysis.status"></status-bar>
-<!-- TODO need a tool to select and order annotation columns -->
-<table class="table table-hover">
-  <thead>
-    <tr>
-      <th> </th>
-      <th>
-        <span class="row-control">
-          <i class="fa fa-bars" aria-hidden="true"></i>
-        </span>
-        ML Data Source
-      </th>
-      <th>id</th>
-      <th>Sample Name</th>
-      <th ng-repeat="at in analysis.exampleCols">{{
-        at.typename
-      }}</th>
-    </tr>
-  </thead>
-  <tbody ng-model="sb.heatmapData.samples" as-sortable="sortableOptions">
-    <tr ng-repeat="id in sb.heatmapData.samples"
-        ng-mouseover="showControls = true" ng-mouseleave="showControls = false"
-        ng-class="'sample-' + sb.sampleToGroup[id]" as-sortable-item>
-      <td class="row-control">
-        <input type="radio" ng-model="sb.sampleToGroup[id]"
-            name="{{id}}-group" value="base-group"
-            class="sample-base-group" aria-label="group a">
-        <input type="radio" ng-model="sb.sampleToGroup[id]"
-            name="{{id}}-group" value="comp-group"
-            class="sample-comp-group" aria-label="group b">
-        <input type="radio" ng-model="sb.sampleToGroup[id]"
-            name="{{id}}-group" value="other"
-            class="sample-other" aria-label="other">
-        &nbsp;
-        <button type="button" class="btn row-control"
-            ng-click="sb.removeSample(id)" aria-label="Delete">
-          <i class="fa fa-times" aria-hidden="true"></i>
-        </button>
-      </td>
-      <td as-sortable-item-handle>
-        <span class="row-control">
-          <i class="fa fa-bars" aria-hidden="true"></i>
-        </span>
-        {{sb.sampleData[id].ml_data_source}}
-      </td>
-      <td>{{id}}</td>
-      <td>{{sb.sampleData[id].name}}</td>
-      <td ng-repeat="at in analysis.exampleCols">{{
-        sb.sampleData[id].annotations[at.typename]
-      }}</td>
-    </tr>
-  </tbody>
-</table>
+  <status-bar msg-text="analysis.status"></status-bar>
+  <!-- TODO need a tool to select and order annotation columns -->
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th> </th>
+        <th>
+          <span class="row-control">
+            <i class="fa fa-bars" aria-hidden="true"></i>
+          </span>
+          ML Data Source
+        </th>
+        <th>id</th>
+        <th>Sample Name</th>
+        <th ng-repeat="at in analysis.exampleCols">{{
+          at.typename
+          }}</th>
+      </tr>
+    </thead>
+    <tbody ng-model="sb.heatmapData.samples" as-sortable="sortableOptions">
+      <tr ng-repeat="id in sb.heatmapData.samples"
+          ng-mouseover="showControls = true"
+          ng-mouseleave="showControls = false"
+          ng-class="'sample-' + sb.sampleToGroup[id]" as-sortable-item>
+        <td class="row-control">
+          <input type="radio" ng-model="sb.sampleToGroup[id]"
+                 name="{{id}}-group" value="base-group"
+                 class="sample-base-group" aria-label="group a">
+          <input type="radio" ng-model="sb.sampleToGroup[id]"
+                 name="{{id}}-group" value="comp-group"
+                 class="sample-comp-group" aria-label="group b">
+          <input type="radio" ng-model="sb.sampleToGroup[id]"
+                 name="{{id}}-group" value="other"
+                 class="sample-other" aria-label="other">
+          &nbsp;
+          <button type="button" class="btn row-control"
+                  ng-click="sb.removeSample(id)" aria-label="Delete">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+        </td>
+        <td as-sortable-item-handle>
+          <span class="row-control">
+            <i class="fa fa-bars" aria-hidden="true"></i>
+          </span>
+          {{sb.sampleData[id].ml_data_source}}
+        </td>
+        <td>{{id}}</td>
+        <td>{{sb.sampleData[id].name}}</td>
+        <td ng-repeat="at in analysis.exampleCols">{{
+          sb.sampleData[id].annotations[at.typename]
+          }}</td>
+      </tr>
+    </tbody>
+  </table>
 
   <p>Note: scroll to the right to see all signatures in the heatmap. Zooming
      feature to come in a future update.</p>

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -3,11 +3,11 @@
 -->
 
 <div class="page-header">
-  <h1>Samples
+  <h3>Samples
     <small>(drag <i class="fa fa-bars" aria-hidden="true"></i> to reorder,
       click <i class="fa fa-times" aria-hidden="true"></i> to delete,
       choose <input type="radio" disabled> to set group)</small>
-  </h1>
+  </h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="modelInUrl" is-valid-model="isValidModel">
   </ml-model-validator>

--- a/interface/src/app/analyze/analysis/analysisDetail.tpl.html
+++ b/interface/src/app/analyze/analysis/analysisDetail.tpl.html
@@ -1,11 +1,20 @@
 <!--
   TODO each sample should be built using a reusable Angular directive
 -->
-<h1>Samples
-  <small>(drag <i class="fa fa-bars" aria-hidden="true"></i> to reorder,
-    click <i class="fa fa-times" aria-hidden="true"></i> to delete,
-    choose <input type="radio" disabled> to set group)</small>
-</h1>
+
+<div class="page-header">
+  <h1>Samples
+    <small>(drag <i class="fa fa-bars" aria-hidden="true"></i> to reorder,
+      click <i class="fa fa-times" aria-hidden="true"></i> to delete,
+      choose <input type="radio" disabled> to set group)</small>
+  </h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="modelInUrl" is-valid-model="isValidModel">
+  </ml-model-validator>
+</div>
+
+<div ng-if="isValidModel">
+
 <status-bar msg-text="analysis.status"></status-bar>
 <!-- TODO need a tool to select and order annotation columns -->
 <table class="table table-hover">
@@ -59,13 +68,7 @@
     </tr>
   </tbody>
 </table>
-<p>To proceed with further analysis, please select a machine learning model.</p>
-<label>Machine learning model:</label>
-<ml-model-selector
-  selected-ml-model="sb.selectedMlModel"
-  on-change="analysis.updateMlModel(value)">
-</ml-model-selector>
-<div ng-show="sb.selectedMlModel.id">
+
   <p>Note: scroll to the right to see all signatures in the heatmap. Zooming
      feature to come in a future update.</p>
   <div vega spec="heatmapSpec" vega-data="sb.heatmapData"></div>
@@ -86,4 +89,5 @@
       Volcano Plot
     </button>
   </nav>
+
 </div>

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -498,11 +498,13 @@ MathFuncts, errGen) {
   return SampleBin;
 }])
 
-.controller('SampleBinCtrl', ['$scope', 'SampleBin',
-function SampleBinCtrl($scope, SampleBin) {
-  // give our templates a way to access the SampleBin service
-  $scope.sb = SampleBin;
-}])
+.controller('SampleBinCtrl', ['$scope', 'SampleBin', 'GlobalModelInfo',
+  function SampleBinCtrl($scope, SampleBin, GlobalModelInfo) {
+    // give our templates a way to access the SampleBin service
+    $scope.sb = SampleBin;
+    $scope.modelInfo = GlobalModelInfo;
+  }
+])
 
 .directive('sampleBin', function() {
   return {

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -498,11 +498,11 @@ MathFuncts, errGen) {
   return SampleBin;
 }])
 
-.controller('SampleBinCtrl', ['$scope', 'SampleBin', 'GlobalModelInfo',
-  function SampleBinCtrl($scope, SampleBin, GlobalModelInfo) {
+.controller('SampleBinCtrl', ['$scope', 'SampleBin', 'MlModelTracker',
+  function SampleBinCtrl($scope, SampleBin, MlModelTracker) {
     // give our templates a way to access the SampleBin service
     $scope.sb = SampleBin;
-    $scope.modelInfo = GlobalModelInfo;
+    $scope.modelInfo = MlModelTracker;
   }
 ])
 

--- a/interface/src/app/analyze/analysis/sampleBin.tpl.html
+++ b/interface/src/app/analyze/analysis/sampleBin.tpl.html
@@ -1,5 +1,5 @@
-<li ui-sref-active="active" class="sample-bin">
-  <a ui-sref="analysis-detail">
+<li ui-sref-active="active" class="sample-bin" ng-if="modelInfo.title">
+  <a ui-sref="analysis-detail({mlmodel: modelInfo.id})">
     <img src="/static/assets/testtube-expt2.svg" alt="Samples"
      width="28" height="28">
     <span ng-if="sb.heatmapData.samples.length" class="badge">{{

--- a/interface/src/app/analyze/analyze.js
+++ b/interface/src/app/analyze/analyze.js
@@ -16,7 +16,7 @@ angular.module('adage.analyze', [
 
 .config(function config($stateProvider) {
   $stateProvider.state('analyze', {
-    url: '/analyze',
+    url: '/analyze?mlmodel',
     views: {
       'main': {
         controller: 'AnalyzeCtrl',
@@ -31,9 +31,19 @@ angular.module('adage.analyze', [
   $anchorScroll.yOffset = 80;
 }])
 
-.controller('AnalyzeCtrl', ['$scope', '$log', '$location',
+.controller('AnalyzeCtrl', ['$scope', '$stateParams', '$log', '$location',
   '$anchorScroll', 'Sample',
-  function AnalyzeCtrl($scope, $log, $location, $anchorScroll, Sample) {
+  function AnalyzeCtrl($scope, $stateParams, $log, $location, $anchorScroll,
+                       Sample) {
+    $scope.isValidModel = false;
+    // Do nothing if mlmodel in URL is falsey. The error will be taken
+    // care of by "<ml-model-validator>" component.
+    if (!$stateParams.mlmodel) {
+      return;
+    }
+
+    $scope.modelInUrl = $stateParams.mlmodel;
+
     $scope.analyze = {
       item_style: function(search_item) {
         // Determine which CSS classes should apply to this search_item.
@@ -53,5 +63,6 @@ angular.module('adage.analyze', [
         $anchorScroll();
       }
     };
-  }])
+  }
+])
 ;

--- a/interface/src/app/analyze/analyze.spec.js
+++ b/interface/src/app/analyze/analyze.spec.js
@@ -1,14 +1,16 @@
 describe('AnalyzeCtrl', function() {
   describe('isCurrentUrl', function() {
-    var AnalyzeCtrl, $location, $scope;
+    var AnalyzeCtrl, $location, $scope, mockStateParams;
 
     beforeEach(module('adage.analyze'));
 
     beforeEach(inject(function($controller, _$location_, $rootScope) {
       $location = _$location_;
       $scope = $rootScope.$new();
+      mockStateParams = {mlmodel: 123};
       AnalyzeCtrl = $controller(
-        'AnalyzeCtrl', {$location: $location, $scope: $scope}
+        'AnalyzeCtrl',
+        {$stateParams: mockStateParams, $location: $location, $scope: $scope}
       );
     }));
 

--- a/interface/src/app/analyze/analyze.tpl.html
+++ b/interface/src/app/analyze/analyze.tpl.html
@@ -5,7 +5,10 @@
   </ml-model-validator>
 </div>
 
-<div ng-if="isValidModel">
+<!-- Use "ng-show" below to make sure that the DOM will be rendered but hidden;
+     "ng-if" will not render the DOM at all when "isValidModel" is falsey, and
+     it will leave "$scope.detail" undefined and cause errors. -->
+<div ng-show="isValidModel">
   <div>
     <div id="search" ng-class="detail.showing ? 'with-detail':''">
       <p>

--- a/interface/src/app/analyze/analyze.tpl.html
+++ b/interface/src/app/analyze/analyze.tpl.html
@@ -1,44 +1,52 @@
-<div>
-  <div id="search" ng-class="detail.showing ? 'with-detail':''">
-    <h1 class="page-header">
-      Analyze
-    </h1>
-    <p>
-      In this area, users will be able to search for an experiment or set of
-      samples to analyze, define analysis groups and generate a DA heatmap to
-      review ADAGE signature intensities for each sample.
-    </p>
-    <div id="search-results" class="col-sm-11">
-      <search placeholder="query text" results="analyze.query_results"></search>
-      <ul class="list-group">
-        <li ng-repeat="search_item in analyze.query_results"
-        ng-class="analyze.item_style(search_item)" class="list-group-item">
-          <a id="{{search_item.pk}}" ng-click="detail.show(search_item)">
-            <div class="media-left">
-              <span ng-if="search_item.item_type === 'experiment'"
-              class="badge">
-                {{ search_item.related_items.length }}
-              </span>
-            </div>
-            <div class="media-body">
-              <button type="button" class="btn"
-              ng-class="sb.hasItem(search_item)?'disabled':''"
-              ng-click="sb.addItem(search_item)">
-                <i class="fa fa-plus" aria-hidden="true"></i>
-              </button>
-              <h4 class="list-group-item-heading">
-                {{search_item.description}}
-              </h4>
-              <p class="list-group-item-text">{{ search_item.pk }}:
-                ...<span ng-bind-html="search_item.snippet"></span>...
-              </p>
-            </div>
-          </a>
-        </li>
-      </ul>
+<div class="page-header">
+  <h1>Analyze</h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="modelInUrl" is-valid-model="isValidModel">
+  </ml-model-validator>
+</div>
+
+<div ng-if="isValidModel">
+  <div>
+    <div id="search" ng-class="detail.showing ? 'with-detail':''">
+      <p>
+        In this area, users will be able to search for an experiment or set of
+        samples to analyze, define analysis groups and generate a DA heatmap to
+        review ADAGE signature intensities for each sample.
+      </p>
+      <div id="search-results" class="col-sm-11">
+        <search placeholder="query text" results="analyze.query_results">
+        </search>
+        <ul class="list-group">
+          <li ng-repeat="search_item in analyze.query_results"
+              ng-class="analyze.item_style(search_item)"
+              class="list-group-item">
+            <a id="{{search_item.pk}}" ng-click="detail.show(search_item)">
+              <div class="media-left">
+                <span ng-if="search_item.item_type === 'experiment'"
+                      class="badge">
+                  {{ search_item.related_items.length }}
+                </span>
+              </div>
+              <div class="media-body">
+                <button type="button" class="btn"
+                        ng-class="sb.hasItem(search_item)?'disabled':''"
+                        ng-click="sb.addItem(search_item)">
+                  <i class="fa fa-plus" aria-hidden="true"></i>
+                </button>
+                <h4 class="list-group-item-heading">
+                  {{search_item.description}}
+                </h4>
+                <p class="list-group-item-text">{{ search_item.pk }}:
+                  ...<span ng-bind-html="search_item.snippet"></span>...
+                </p>
+              </div>
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-  <div id="search-detail" ng-show="detail.showing" class="col-sm-6">
-    <search-detail></search-detail>
+    <div id="search-detail" ng-show="detail.showing" class="col-sm-6">
+      <search-detail></search-detail>
+    </div>
   </div>
 </div>

--- a/interface/src/app/analyze/analyze.tpl.html
+++ b/interface/src/app/analyze/analyze.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>Analyze</h1>
+  <h3>Analyze</h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="modelInUrl" is-valid-model="isValidModel">
   </ml-model-validator>

--- a/interface/src/app/app.js
+++ b/interface/src/app/app.js
@@ -31,10 +31,10 @@ angular.module('adage', [
   $resourceProvider.defaults.stripTrailingSlashes = false;
 }])
 
-.controller('AppCtrl', ['$scope', '$state', 'UserFactory', 'GlobalModelInfo',
-  function AppCtrl($scope, $state, UserFactory, GlobalModelInfo) {
+.controller('AppCtrl', ['$scope', '$state', 'UserFactory', 'MlModelTracker',
+  function AppCtrl($scope, $state, UserFactory, MlModelTracker) {
     // Machine learning model
-    $scope.modelInfo = GlobalModelInfo;
+    $scope.modelInfo = MlModelTracker;
 
     // Function that indicates whether the current state is 'gene_search'
     // or 'gene_network'. (Used by index.html to highlight the 'GeneNetwork'

--- a/interface/src/app/app.js
+++ b/interface/src/app/app.js
@@ -1,4 +1,6 @@
 angular.module('adage', [
+  'ui.router',
+  'ngResource',
   'templates-app',
   'templates-common',
   'adage.home',
@@ -16,8 +18,7 @@ angular.module('adage', [
   'adage.help',
   'adage.sampleAnnotation',
   'adage.volcano-plot.view',
-  'ui.router',
-  'ngResource'
+  'adage.utils'
 ])
 
 .config(function myAppConfig($stateProvider, $urlRouterProvider) {
@@ -30,8 +31,11 @@ angular.module('adage', [
   $resourceProvider.defaults.stripTrailingSlashes = false;
 }])
 
-.controller('AppCtrl', ['$scope', '$state', 'UserFactory',
-  function AppCtrl($scope, $state, UserFactory) {
+.controller('AppCtrl', ['$scope', '$state', 'UserFactory', 'GlobalModelInfo',
+  function AppCtrl($scope, $state, UserFactory, GlobalModelInfo) {
+    // Machine learning model
+    $scope.modelInfo = GlobalModelInfo;
+
     // Function that indicates whether the current state is 'gene_search'
     // or 'gene_network'. (Used by index.html to highlight the 'GeneNetwork'
     // tab on web UI in either state.)
@@ -53,7 +57,8 @@ angular.module('adage', [
         if (angular.isDefined(toState.data.pageTitle)) {
           $scope.pageTitle = toState.data.pageTitle + ' | adage';
         }
-      });
+      }
+    );
 
     UserFactory.getPromise().then(function() {
       $scope.userObj = UserFactory.getUser();

--- a/interface/src/app/download/download.tpl.html
+++ b/interface/src/app/download/download.tpl.html
@@ -1,4 +1,6 @@
-<h1>ADAGE: Download Sample Annotations Selectively</h1>
+<div class="page-header">
+  <h1>ADAGE: Download Sample Annotations Selectively</h1>
+</div>
 
 <div ng-bind="ctrl.queryStatus"></div>
 

--- a/interface/src/app/download/download.tpl.html
+++ b/interface/src/app/download/download.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>ADAGE: Download Sample Annotations Selectively</h1>
+  <h3>ADAGE: Download Sample Annotations Selectively</h3>
 </div>
 
 <div ng-bind="ctrl.queryStatus"></div>

--- a/interface/src/app/gene/gene-network.tpl.html
+++ b/interface/src/app/gene/gene-network.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>Gene Network</h1>
+  <h3>Gene Network</h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="searchCtrl.modelInUrl"
                       is-valid-model="searchCtrl.isValidModel">

--- a/interface/src/app/gene/gene-network.tpl.html
+++ b/interface/src/app/gene/gene-network.tpl.html
@@ -1,14 +1,12 @@
-<div>
-  <h1 class="page-header">
-    Gene Network
-  </h1>
+<div class="page-header">
+  <h1>Gene Network</h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="searchCtrl.modelInUrl"
+                      is-valid-model="searchCtrl.isValidModel">
+  </ml-model-validator>
+</div>
 
-  <div class="well">
-    <h3>Machine Learning Model</h3>
-    <ml-model-selector selected-ml-model="searchCtrl.selectedMlModel">
-    </ml-model-selector>
-  </div>
-
+<div ng-if="searchCtrl.isValidModel">
   <autocomplete-search-panel
     ng-if="searchCtrl.autocomplete"
     autocomplete="searchCtrl.autocomplete"

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -44,12 +44,6 @@ angular.module('adage.gene.network', [
 
 .factory('Edge', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
-  // Possible parameters for this endpoint when making a query are:
-  // {
-  //   genes: Database IDs of genes associated with the edge,
-  //   mlmodel: Database ID of MLModel associated with the edge,
-  //   limit: Maximum number of results to return
-  //  }
     return $resource(ApiBasePath + 'edge');
   }
 ])
@@ -64,8 +58,17 @@ angular.module('adage.gene.network', [
   ['$stateParams', 'Edge', 'Signature', 'Gene', 'ExpressionValue', '$log',
     'errGen',
     function GeneNetworkController($stateParams, Edge, Signature, Gene,
-                                 ExpressionValue, $log, errGen) {
+                                   ExpressionValue, $log, errGen) {
       var self = this;
+      self.isValidModel = false;
+      // Do nothing if mlmodel in URL is falsey. The error will be taken
+      // care of by "<ml-model-validator>" component.
+      if (!$stateParams.mlmodel) {
+        return;
+      }
+
+      self.modelInUrl = $stateParams.mlmodel;
+
       // Do nothing if no genes are specified in URL.
       if (!$stateParams.genes || !$stateParams.genes.split(',').length) {
         self.statusMessage = 'No genes are specified.';
@@ -285,7 +288,7 @@ angular.module('adage.gene.network', [
           htmlText += data.weight.toFixed(weightPrecision);
           var heavyGenes = [data.gene1.id, data.gene2.id].join(',');
           var target = d3.event.target;
-          Signaure.get(
+          Signature.get(
             {'heavy_genes': heavyGenes, 'limit': 0},
             function success(response) {
               var i = 0, n = response.objects.length;

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -56,9 +56,11 @@ angular.module('adage.gene.network', [
 
 .controller('GeneNetworkCtrl',
   ['$stateParams', 'Edge', 'Signature', 'Gene', 'ExpressionValue', '$log',
-    'errGen',
-    function GeneNetworkController($stateParams, Edge, Signature, Gene,
-                                   ExpressionValue, $log, errGen) {
+    'errGen', '$httpParamSerializerJQLike',
+    function GeneNetworkController(
+      $stateParams, Edge, Signature, Gene, ExpressionValue, $log, errGen,
+      $httpParamSerializerJQLike
+    ) {
       var self = this;
       self.isValidModel = false;
       // Do nothing if mlmodel in URL is falsey. The error will be taken

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -6,8 +6,13 @@
   </ml-model-validator>
 </div>
 
-<div ng-if="ctrl.isValidModel">
+<!-- Unlike the other HTML template files, this one is using "ng-show" here
+     instead of "ng-if". The reason is that when "ng-if" is used to enclose
+     the <div> section, the "rzslider" inside won't be rendered correctly.
+  -->
+<div ng-show="ctrl.isValidModel">
   <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
+
   <div ng-hide="ctrl.statusMessage">
     <form>
       <strong>Correlation Range:</strong>
@@ -25,17 +30,16 @@
         Include positive correlation
       </label>
     </form>
-    <rzslider
-       rz-slider-model="ctrl.slider.min"
-       rz-slider-high="ctrl.slider.max"
-       rz-slider-options="ctrl.slider.options">
+    <rzslider rz-slider-model="ctrl.slider.min"
+              rz-slider-high="ctrl.slider.max"
+              rz-slider-options="ctrl.slider.options">
     </rzslider>
   </div>
-
-  <!-- DO NOT put the following "chart" div into a div that is controlled by
-       "ng-hide" of "ng-if", otherwise the legend bar in d3.network won't be
-       rendered correctly (some of the legend marks may be absent).
-       See details in GitHub Issue #25.
-    -->
-  <div id="chart"></div>
 </div>
+
+<!-- DO NOT put the following "chart" div into a div that is controlled by
+     "ng-hide" of "ng-if", otherwise the legend bar in d3.network won't be
+     rendered correctly (some of the legend marks may be absent).
+     See details in GitHub Issue #25.
+  -->
+<div id="chart"></div>

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -1,34 +1,41 @@
-<h1>ADAGE: Gene-Gene Network</h1>
-
-<div ng-hide="ctrl.statusMessage">
-  <form>
-    <strong>Correlation Range:</strong>
-    <label>
-      <input type="checkbox" ng-model="ctrl.includeNegative"
-             ng-disabled="!ctrl.includePositive"
-             ng-change="ctrl.renderNetwork()">
-      Include negative correlation
-    </label>
-    &nbsp;
-    <label>
-      <input type="checkbox" ng-model="ctrl.includePositive"
-             ng-disabled="!ctrl.includeNegative"
-             ng-change="ctrl.renderNetwork()">
-      Include positive correlation
-    </label>
-  </form>
-  <rzslider
-     rz-slider-model="ctrl.slider.min"
-     rz-slider-high="ctrl.slider.max"
-     rz-slider-options="ctrl.slider.options">
-  </rzslider>
+<div class="page-header">
+  <h1>ADAGE: Gene-Gene Network</h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="ctrl.modelInUrl"
+                      is-valid-model="ctrl.isValidModel">
+  </ml-model-validator>
 </div>
 
-<!-- DO NOT put the following "chart" div into a div that is controlled by
-     "ng-hide" of "ng-if", otherwise the legend bar in d3.network won't be
-     rendered correctly (some of the legend marks may be absent).
-     See details in GitHub Issue #25.
-  -->
-<div id="chart"></div>
+<div ng-if="ctrl.isValidModel">
+  <div ng-hide="ctrl.statusMessage">
+    <form>
+      <strong>Correlation Range:</strong>
+      <label>
+        <input type="checkbox" ng-model="ctrl.includeNegative"
+               ng-disabled="!ctrl.includePositive"
+               ng-change="ctrl.renderNetwork()">
+        Include negative correlation
+      </label>
+      &nbsp;
+      <label>
+        <input type="checkbox" ng-model="ctrl.includePositive"
+               ng-disabled="!ctrl.includeNegative"
+               ng-change="ctrl.renderNetwork()">
+        Include positive correlation
+      </label>
+    </form>
+    <rzslider
+       rz-slider-model="ctrl.slider.min"
+       rz-slider-high="ctrl.slider.max"
+       rz-slider-options="ctrl.slider.options">
+    </rzslider>
+  </div>
 
-<h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
+  <!-- DO NOT put the following "chart" div into a div that is controlled by
+       "ng-hide" of "ng-if", otherwise the legend bar in d3.network won't be
+       rendered correctly (some of the legend marks may be absent).
+       See details in GitHub Issue #25.
+    -->
+  <div id="chart"></div>
+  <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
+</div>

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>ADAGE: Gene-Gene Network</h1>
+  <h3>ADAGE: Gene-Gene Network</h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="ctrl.modelInUrl"
                       is-valid-model="ctrl.isValidModel">

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -7,6 +7,7 @@
 </div>
 
 <div ng-if="ctrl.isValidModel">
+  <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
   <div ng-hide="ctrl.statusMessage">
     <form>
       <strong>Correlation Range:</strong>
@@ -37,5 +38,4 @@
        See details in GitHub Issue #25.
     -->
   <div id="chart"></div>
-  <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
 </div>

--- a/interface/src/app/gene/searchMany/searchMany.js
+++ b/interface/src/app/gene/searchMany/searchMany.js
@@ -14,8 +14,8 @@ angular.module('adage.gene.searchMany', [
       views: {
         'main': {
           templateUrl: 'gene/gene-network.tpl.html',
-          controller: ['$stateParams', 'GlobalModelInfo', 'UserFactory',
-          function($stateParams, GlobalModelInfo, UserFactory) {
+          controller: ['$stateParams', 'MlModelTracker', 'UserFactory',
+          function($stateParams, MlModelTracker, UserFactory) {
             var self = this;
             self.isValidModel = false;
             // Do nothing if mlmodel in URL is falsey. The error will be taken
@@ -25,7 +25,7 @@ angular.module('adage.gene.searchMany', [
             }
 
             self.modelInUrl = $stateParams.mlmodel;
-            self.selectedMlModel = GlobalModelInfo;
+            self.selectedMlModel = MlModelTracker;
             self.userObj = null;
             UserFactory.getPromise().then(function() {
               self.userObj = UserFactory.getUser();

--- a/interface/src/app/gene/searchMany/searchMany.js
+++ b/interface/src/app/gene/searchMany/searchMany.js
@@ -1,19 +1,31 @@
 angular.module('adage.gene.searchMany', [
+  'ui.router',
   'adage.gene.resource',
   'adage.gene.utils',
   'adage.gene.selected',
+  'adage.utils',
   'adage.mlmodel.components'
 ])
 
 .config(function($stateProvider) {
   $stateProvider
     .state('gene_search', {
-      url: '/gene_search',
+      url: '/gene_search?mlmodel',
       views: {
         'main': {
           templateUrl: 'gene/gene-network.tpl.html',
-          controller: ['UserFactory', function(UserFactory) {
+          controller: ['$stateParams', 'GlobalModelInfo', 'UserFactory',
+          function($stateParams, GlobalModelInfo, UserFactory) {
             var self = this;
+            self.isValidModel = false;
+            // Do nothing if mlmodel in URL is falsey. The error will be taken
+            // care of by "<ml-model-validator>" component.
+            if (!$stateParams.mlmodel) {
+              return;
+            }
+
+            self.modelInUrl = $stateParams.mlmodel;
+            self.selectedMlModel = GlobalModelInfo;
             self.userObj = null;
             UserFactory.getPromise().then(function() {
               self.userObj = UserFactory.getUser();

--- a/interface/src/app/help/help.tpl.html
+++ b/interface/src/app/help/help.tpl.html
@@ -1,6 +1,7 @@
 <div>
-  <h1>Help</h1>
-  <br>
+  <div class="page-header">
+    <h1>Help</h1>
+  </div>
 
   <div class="lead" id="Expression compendium">
     <h3><u>Expression compendium</u></h3>

--- a/interface/src/app/home/home.js
+++ b/interface/src/app/home/home.js
@@ -29,13 +29,11 @@ angular.module('adage.home', [
 /**
  * And of course we define a controller for our route.
  */
-.controller('HomeCtrl', ['GlobalModelInfo',
-  function HomeController(GlobalModelInfo) {
-    var self = this;
-    self.modelInfo = GlobalModelInfo;
-    self.changeModel = function(newModel) {
-      GlobalModelInfo.set(newModel);
-    };
-  }
-])
+.controller('HomeCtrl', ['GlobalModelInfo', function(GlobalModelInfo) {
+  var self = this;
+  self.modelInfo = GlobalModelInfo;
+  self.changeModel = function(newModel) {
+    GlobalModelInfo.set(newModel);
+  };
+}])
 ;

--- a/interface/src/app/home/home.js
+++ b/interface/src/app/home/home.js
@@ -29,11 +29,11 @@ angular.module('adage.home', [
 /**
  * And of course we define a controller for our route.
  */
-.controller('HomeCtrl', ['GlobalModelInfo', function(GlobalModelInfo) {
+.controller('HomeCtrl', ['MlModelTracker', function(MlModelTracker) {
   var self = this;
-  self.modelInfo = GlobalModelInfo;
+  self.modelInfo = MlModelTracker;
   self.changeModel = function(newModel) {
-    GlobalModelInfo.set(newModel);
+    MlModelTracker.set(newModel);
   };
 }])
 ;

--- a/interface/src/app/home/home.js
+++ b/interface/src/app/home/home.js
@@ -1,20 +1,11 @@
 /**
- * Each section of the site has its own module. It probably also has
- * submodules, though this boilerplate is too simple to demonstrate it. Within
- * `src/app/home`, however, could exist several additional folders representing
- * additional modules that would then be listed as dependencies of this one.
- * For example, a `note` section could have the submodules `note.create`,
- * `note.delete`, `note.edit`, etc.
- *
- * Regardless, so long as dependencies are managed correctly, the build process
- * will automatically take care of the rest.
- *
- * The dependencies block here is also where component dependencies should be
- * specified, as shown below.
+ * adage.home module.
  */
 angular.module('adage.home', [
   'ui.router',
-  'plusOne'
+  'ui.bootstrap',
+  'adage.mlmodel.components',
+  'adage.utils'
 ])
 
 /**
@@ -27,7 +18,7 @@ angular.module('adage.home', [
     url: '/home',
     views: {
       'main': {
-        controller: 'HomeCtrl',
+        controller: 'HomeCtrl as ctrl',
         templateUrl: 'home/home.tpl.html'
       }
     },
@@ -38,7 +29,13 @@ angular.module('adage.home', [
 /**
  * And of course we define a controller for our route.
  */
-.controller('HomeCtrl', function HomeController($scope) {
-})
-
+.controller('HomeCtrl', ['GlobalModelInfo',
+  function HomeController(GlobalModelInfo) {
+    var self = this;
+    self.modelInfo = GlobalModelInfo;
+    self.changeModel = function(newModel) {
+      GlobalModelInfo.set(newModel);
+    };
+  }
+])
 ;

--- a/interface/src/app/home/home.tpl.html
+++ b/interface/src/app/home/home.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>ADAGE: Home</h1>
+  <h3>ADAGE: Home</h3>
 </div>
 
 <h3>Step 1: Choose a machine learning model</h3>

--- a/interface/src/app/home/home.tpl.html
+++ b/interface/src/app/home/home.tpl.html
@@ -1,6 +1,32 @@
-<div>
+<div class="page-header">
   <h1>ADAGE: Home</h1>
-  <p class="lead">
-    This shell is the framework into which the ADAGE server will grow.
-  </p>
+</div>
+
+<h3>Step 1: Choose a machine leanring model</h3>
+<ml-model-selector selected-ml-model="ctrl.modelInfo"
+                   on-change="ctrl.changeModel(value)">
+</ml-model-selector>
+
+<hr>
+<div ng-show="ctrl.modelInfo.title">
+  <h3>Step 2: Now that the model is set, you have three options:</h3>
+    <ul>
+      <li>
+        <h4><a ui-sref="analyze({mlmodel: modelInfo.id})">
+            Explore assays and experiments
+        </a></h4>
+      </li>
+
+      <li>
+        <h4><a ui-sref="gene_search({mlmodel: modelInfo.id})">
+            Explore genes' model similarities
+        </a></h4>
+      </li>
+
+      <li>
+        <h4><a ui-sref="signature_search({mlmodel: modelInfo.id})">
+            Explore model signatures
+        </a></h4>
+      </li>
+    </ul>
 </div>

--- a/interface/src/app/home/home.tpl.html
+++ b/interface/src/app/home/home.tpl.html
@@ -2,7 +2,7 @@
   <h1>ADAGE: Home</h1>
 </div>
 
-<h3>Step 1: Choose a machine leanring model</h3>
+<h3>Step 1: Choose a machine learning model</h3>
 <ml-model-selector selected-ml-model="ctrl.modelInfo"
                    on-change="ctrl.changeModel(value)">
 </ml-model-selector>

--- a/interface/src/app/mlmodel/mlModelComponents.js
+++ b/interface/src/app/mlmodel/mlModelComponents.js
@@ -33,8 +33,8 @@ angular.module('adage.mlmodel.components', [
 
 .component('mlModelView', {
   templateUrl: 'mlmodel/view.tpl.html',
-  controller: ['GlobalModelInfo', function(GlobalModelInfo) {
-    this.modelInfo = GlobalModelInfo;
+  controller: ['MlModelTracker', function(MlModelTracker) {
+    this.modelInfo = MlModelTracker;
   }]
 })
 
@@ -44,16 +44,16 @@ angular.module('adage.mlmodel.components', [
     modelId: '=',
     isValidModel: '='
   },
-  controller: ['MlModel', 'GlobalModelInfo', '$log', 'errGen',
-    function(MlModel, GlobalModelInfo, $log, errGen) {
+  controller: ['MlModel', 'MlModelTracker', '$log', 'errGen',
+    function(MlModel, MlModelTracker, $log, errGen) {
       var self = this;
       // Ensure that input modelId is truthy.
       if (!self.modelId) {
         self.errMessage = 'Machine learning model not set yet.';
         return;
       }
-      // Do nothing if GlobalModelInfo has same ID as the input model ID.
-      if (self.modelId === GlobalModelInfo.id) {
+      // Do nothing if MlModelTracker has same ID as the input model ID.
+      if (self.modelId === MlModelTracker.id) {
         self.isValidModel = true;
         return;
       }
@@ -61,11 +61,11 @@ angular.module('adage.mlmodel.components', [
       MlModel.get(
         {id: self.modelId},
         function success(response) {
-          GlobalModelInfo.set(response);
+          MlModelTracker.set(response);
           self.isValidModel = true;
         },
         function error(err) {
-          GlobalModelInfo.reset();
+          MlModelTracker.reset();
           self.errMessage = errGen('Failed to get machine learning model', err);
           $log.error(self.errorMessage);
         }

--- a/interface/src/app/mlmodel/mlModelComponents.js
+++ b/interface/src/app/mlmodel/mlModelComponents.js
@@ -1,4 +1,5 @@
 angular.module('adage.mlmodel.components', [
+  'adage.utils',
   'adage.mlmodel.resource'
 ])
 
@@ -30,4 +31,45 @@ angular.module('adage.mlmodel.components', [
   }]
 })
 
+.component('mlModelView', {
+  templateUrl: 'mlmodel/view.tpl.html',
+  controller: ['GlobalModelInfo', function(GlobalModelInfo) {
+    this.modelInfo = GlobalModelInfo;
+  }]
+})
+
+.component('mlModelValidator', {
+  templateUrl: 'mlmodel/validator.tpl.html',
+  bindings: {
+    modelId: '=',
+    isValidModel: '='
+  },
+  controller: ['MlModel', 'GlobalModelInfo', '$log', 'errGen',
+    function(MlModel, GlobalModelInfo, $log, errGen) {
+      var self = this;
+      // Ensure that input modelId is truthy.
+      if (!self.modelId) {
+        self.errMessage = 'Machine learning model not set yet.';
+        return;
+      }
+      // Do nothing if GlobalModelInfo has same ID as the input model ID.
+      if (self.modelId === GlobalModelInfo.id) {
+        self.isValidModel = true;
+        return;
+      }
+
+      MlModel.get(
+        {id: self.modelId},
+        function success(response) {
+          GlobalModelInfo.set(response);
+          self.isValidModel = true;
+        },
+        function error(err) {
+          GlobalModelInfo.reset();
+          self.errMessage = errGen('Failed to get machine learning model', err);
+          $log.error(self.errorMessage);
+        }
+      );
+    }]
+})
 ;

--- a/interface/src/app/mlmodel/resource.js
+++ b/interface/src/app/mlmodel/resource.js
@@ -2,7 +2,7 @@ angular.module('adage.mlmodel.resource', ['ngResource'])
 
 .factory('MlModel', ['$resource', function($resource) {
   return $resource(
-    '/api/v0/mlmodel/'
+    '/api/v0/mlmodel/:id'
   );
 }])
 

--- a/interface/src/app/mlmodel/validator.tpl.html
+++ b/interface/src/app/mlmodel/validator.tpl.html
@@ -1,0 +1,5 @@
+<div class="alert alert-danger" role="alert" ng-if="$ctrl.errMessage">
+  {{$ctrl.errMessage}}
+  <br>
+  Please click <a href="#/home">Home</a> to reset it.
+</div>

--- a/interface/src/app/mlmodel/view.tpl.html
+++ b/interface/src/app/mlmodel/view.tpl.html
@@ -1,0 +1,6 @@
+<h4>
+  <span>Current Model: </span>
+  <span class="text-danger" ng-bind="$ctrl.modelInfo.title || 'Not Set'">
+  </span>
+  <span>(Click <a href="#/home">Home</a> to change)</span>
+</h4>

--- a/interface/src/app/sample_annotation/annotation.js
+++ b/interface/src/app/sample_annotation/annotation.js
@@ -12,7 +12,7 @@ angular.module('adage.sampleAnnotation', [
 
 .config(['$stateProvider', function($stateProvider) {
   $stateProvider.state('sampleAnnotation', {
-    url: '/sample_annotation?signature&samples',
+    url: '/sample_annotation?mlmodel&signature&samples',
     views: {
       main: {
         templateUrl: 'sample_annotation/annotation.tpl.html',
@@ -28,14 +28,21 @@ angular.module('adage.sampleAnnotation', [
   'ActivityDigits',
   function($stateParams, $q, $log, errGen, Activity, Sample, ActivityDigits) {
     var self = this;
-    self.queryStatus = 'Connecting to the server ...';
+    self.isValidModel = false;
+    // Do nothing if mlmodel in URL is falsey. The error will be taken
+    // care of by "<ml-model-validator>" component.
+    if (!$stateParams.mlmodel) {
+      return;
+    }
+
+    self.modelInUrl = $stateParams.mlmodel;
 
     // Ensure that the URL includes sample ID(s).
     if (!$stateParams.samples) {
       self.queryStatus = 'Please specify sample ID(s) in the URL.';
       return;
     }
-
+    self.queryStatus = 'Connecting to the server ...';
     var samplesInUrl = $stateParams.samples;
     self.uniqueAnnotationTypes = [];
     // Note: Ideally self.uniqueAnnotationTypes should be a hashtable (such as

--- a/interface/src/app/sample_annotation/annotation.spec.js
+++ b/interface/src/app/sample_annotation/annotation.spec.js
@@ -21,12 +21,15 @@ describe('sample_annotation', function() {
   });
 
   describe('SampleAnnotationCtrl', function() {
-    var SampleAnnotationCtrl, mockStateParams;
+    var SampleAnnotationCtrl, mockStateParams, mockGlobalModelInfo;
 
     beforeEach(inject(function($controller) {
-      mockStateParams = {samples: '1'};
+      var modelID = 23;
+      mockStateParams = {samples: '1', mlmodel: modelID};
+      mockGlobalModelInfo = {id: modelID, title: 'test model', organism: null};
       SampleAnnotationCtrl = $controller('SampleAnnotationCtrl', {
-        $stateParams: mockStateParams
+        $stateParams: mockStateParams,
+        GlobalModelInfo: mockGlobalModelInfo
       });
     }));
 

--- a/interface/src/app/sample_annotation/annotation.spec.js
+++ b/interface/src/app/sample_annotation/annotation.spec.js
@@ -21,15 +21,15 @@ describe('sample_annotation', function() {
   });
 
   describe('SampleAnnotationCtrl', function() {
-    var SampleAnnotationCtrl, mockStateParams, mockGlobalModelInfo;
+    var SampleAnnotationCtrl, mockStateParams, mockMlModelTracker;
 
     beforeEach(inject(function($controller) {
       var modelID = 23;
       mockStateParams = {samples: '1', mlmodel: modelID};
-      mockGlobalModelInfo = {id: modelID, title: 'test model', organism: null};
+      mockMlModelTracker = {id: modelID, title: 'test model', organism: null};
       SampleAnnotationCtrl = $controller('SampleAnnotationCtrl', {
         $stateParams: mockStateParams,
-        GlobalModelInfo: mockGlobalModelInfo
+        MlModelTracker: mockMlModelTracker
       });
     }));
 

--- a/interface/src/app/sample_annotation/annotation.tpl.html
+++ b/interface/src/app/sample_annotation/annotation.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>ADAGE: Sample Annotations</h1>
+  <h3>ADAGE: Sample Annotations</h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="ctrl.modelInUrl"
                       is-valid-model="ctrl.isValidModel">

--- a/interface/src/app/sample_annotation/annotation.tpl.html
+++ b/interface/src/app/sample_annotation/annotation.tpl.html
@@ -1,29 +1,36 @@
-<h1>ADAGE: Sample Annotations</h1>
+<div class="page-header">
+  <h1>ADAGE: Sample Annotations</h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="ctrl.modelInUrl"
+                      is-valid-model="ctrl.isValidModel">
+  </ml-model-validator>
+</div>
 
-<h3 class="text-warning" ng-bind="ctrl.queryStatus"></h3>
+<div ng-if="ctrl.isValidModel">
+  <h3 class="text-warning" ng-bind="ctrl.queryStatus"></h3>
 
-<table ng-hide="ctrl.queryStatus"
-       class="table table-bordered table-striped table-hover table-condensed">
-  <thead>
-    <th ng-if="ctrl.hasSignature">Activity</th>
-    <th>Sample Name</th>
-    <th>Data Source</th>
-    <th ng-repeat="typeName in ctrl.uniqueAnnotationTypes">
-      {{typeName}}
-    </th>
-  </thead>
-
-  <tbody>
-    <tr ng-repeat=
-        "sample in ctrl.samples | orderBy: ctrl.hasSignature ? '-activity' : 'name'">
-      <td ng-if="ctrl.hasSignature">
-        <strong>{{sample.activity | number: ctrl.activityDigits}}</strong>
-      </td>
-      <td>{{sample.name}}</td>
-      <td>{{sample.dataSource}}</td>
-      <td ng-repeat="typeName in ctrl.uniqueAnnotationTypes">
-        {{sample.annotations[typeName] ? sample.annotations[typeName] : ""}}
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table ng-hide="ctrl.queryStatus"
+         class="table table-bordered table-striped table-hover table-condensed">
+    <thead>
+      <th ng-if="ctrl.hasSignature">Activity</th>
+      <th>Sample Name</th>
+      <th>Data Source</th>
+      <th ng-repeat="typeName in ctrl.uniqueAnnotationTypes">
+        {{typeName}}
+      </th>
+    </thead>
+    <tbody>
+      <tr ng-repeat=
+          "sample in ctrl.samples | orderBy: ctrl.hasSignature ? '-activity' : 'name'">
+        <td ng-if="ctrl.hasSignature">
+          <strong>{{sample.activity | number: ctrl.activityDigits}}</strong>
+        </td>
+        <td>{{sample.name}}</td>
+        <td>{{sample.dataSource}}</td>
+        <td ng-repeat="typeName in ctrl.uniqueAnnotationTypes">
+          {{sample.annotations[typeName] ? sample.annotations[typeName] : ""}}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -21,9 +21,11 @@
           <b>{{$index + 1}}. {{exp.accession}}: </b>{{exp.name}}
           <!-- vega-lite widget. If it is clicked, go to sample annotations
                page. -->
-          <a ui-sref="sampleAnnotation(
-                      {signature: signatureId, samples: exp.sample_set.join()}
-                      )">
+          <a ui-sref="sampleAnnotation({
+                      mlmodel: modelId,
+                      signature: signatureId,
+                      samples: exp.sample_set.join()
+                     })">
             <!-- The UI would look nicer if the tooltip showed up on the right
                  side of the activity distribution map (instead of left side).
                  But because the vega-lite widget takes the full width of the

--- a/interface/src/app/signature/resources.js
+++ b/interface/src/app/signature/resources.js
@@ -23,7 +23,7 @@ angular.module('adage.signature.resources', [
   }
 ])
 
-.factory('Experiment', ['$resource', 'ApiBasePath',
+.factory('SignatureExperiment', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
     return $resource(ApiBasePath + 'experiment');
   }

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -23,8 +23,10 @@ angular.module('adage.signature', [
   });
 }])
 
-.controller('SignatureCtrl', ['Signature', '$stateParams', '$log',
-  function SignatureController(Signature, $stateParams, $log) {
+.controller('SignatureCtrl', ['Signature', '$stateParams', 'GlobalModelInfo',
+  '$log', 'errGen',
+  function SignatureController(Signature, $stateParams, GlobalModelInfo, $log,
+                               errGen) {
     var self = this;
     if (!$stateParams.id) {
       self.statusMessage = 'Please specify signature ID in the URL.';
@@ -36,12 +38,17 @@ angular.module('adage.signature', [
       {id: self.id},
       function success(response) {
         self.name = response.name;
-        self.mlmodel = response.mlmodel.title;
+        GlobalModelInfo.set(response.mlmodel);
+        self.modelID = GlobalModelInfo.id;
+        console.log('self.modelID: ' + self.modelID);
         self.statusMessage = '';
       },
-      function error(err) {
-        $log.error('Failed to get signature information: ' + err.statusText);
-        self.statusMessage = 'Failed to get signature information from server';
+      function error(errObj) {
+        GlobalModelInfo.init();
+        var errMessage = errGen('Failed to get signature from server', errObj);
+        $log.error(errMessage);
+        self.statusMessage = errMessage +
+          '. Please check the signature ID and/or try again later.';
       }
     );
     self.organism = 'Pseudomonas aeruginosa';
@@ -161,6 +168,7 @@ angular.module('adage.signature', [
       templateUrl: 'signature/high_range_exp.tpl.html',
       restrict: 'E',
       scope: {
+        modelId: '@',
         signatureId: '@',
         inputTopNum: '@topExp'
       },

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -23,9 +23,9 @@ angular.module('adage.signature', [
   });
 }])
 
-.controller('SignatureCtrl', ['Signature', '$stateParams', 'GlobalModelInfo',
+.controller('SignatureCtrl', ['Signature', '$stateParams', 'MlModelTracker',
   '$log', 'errGen',
-  function SignatureController(Signature, $stateParams, GlobalModelInfo, $log,
+  function SignatureController(Signature, $stateParams, MlModelTracker, $log,
                                errGen) {
     var self = this;
     if (!$stateParams.id) {
@@ -38,13 +38,13 @@ angular.module('adage.signature', [
       {id: self.id},
       function success(response) {
         self.name = response.name;
-        GlobalModelInfo.set(response.mlmodel);
-        self.modelID = GlobalModelInfo.id;
+        MlModelTracker.set(response.mlmodel);
+        self.modelID = MlModelTracker.id;
         console.log('self.modelID: ' + self.modelID);
         self.statusMessage = '';
       },
       function error(errObj) {
-        GlobalModelInfo.init();
+        MlModelTracker.init();
         var errMessage = errGen('Failed to get signature from server', errObj);
         $log.error(errMessage);
         self.statusMessage = errMessage +

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -161,9 +161,9 @@ angular.module('adage.signature', [
   };
 }])
 
-.directive('highRangeExp', ['Activity', 'Experiment', 'EmbedSpecService',
-  'errGen', '$log',
-  function(Activity, Experiment, EmbedSpecService, errGen, $log) {
+.directive('highRangeExp', ['Activity', 'SignatureExperiment',
+  'EmbedSpecService', 'errGen', '$log',
+  function(Activity, SignatureExperiment, EmbedSpecService, errGen, $log) {
     return {
       templateUrl: 'signature/high_range_exp.tpl.html',
       restrict: 'E',
@@ -267,7 +267,7 @@ angular.module('adage.signature', [
               sampleID = response.objects[i].sample;
               $scope.activities[sampleID] = response.objects[i].value;
             }
-            return Experiment.get({node: $scope.signatureId, limit: 0})
+            return SignatureExperiment.get({node: $scope.signatureId, limit: 0})
               .$promise;
           },
           function error(response) {

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>Signature: {{ctrl.name}}</h1>
+  <h3>Signature: {{ctrl.name}}</h3>
   <ml-model-view></ml-model-view>
 </div>
 

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -1,9 +1,11 @@
-<h1>ADAGE: Signature Information</h1>
+<div class="page-header">
+  <h1>Signature: {{ctrl.name}}</h1>
+  <ml-model-view></ml-model-view>
+</div>
+
+<h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
 
 <div ng-if="!ctrl.statusMessage">
-  <h3>{{ctrl.name}}</h3>
-  <h4>(Model: {{ctrl.mlmodel}})</h4>
-  <hr>
   <div class="container">
     <div class="row">
       <div class="col-xs-6">
@@ -12,7 +14,8 @@
       </div>
 
       <div class="col-xs-6">
-        <high-range-exp signature-id="{{ctrl.id}}" top-exp="20">
+        <high-range-exp signature-id="{{ctrl.id}}" model-id="{{ctrl.modelID}}"
+                        top-exp="20">
         </high-range-exp>
       </div>
     </div>
@@ -27,5 +30,3 @@
     </div>
   </div>
 </div>
-
-<h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>

--- a/interface/src/app/signature/signature_search.js
+++ b/interface/src/app/signature/signature_search.js
@@ -5,58 +5,58 @@
 angular.module('adage.signatureSearch', [
   'ui.router',
   'ui.bootstrap',
+  'adage.mlmodel.components',
   'adage.signature.resources',
-  'adage.mlmodel.components'
+  'adage.utils'
 ])
 
 .config(['$stateProvider', function($stateProvider) {
   $stateProvider.state('signature_search', {
-    url: '/signature/search',
+    url: '/signature/search?mlmodel',
     views: {
       main: {
         templateUrl: 'signature/signature_search.tpl.html',
-        controller: 'SignatureSearchCtrl'
-        // See comments below on why "controllerAs" is not used.
+        controller: 'SignatureSearchCtrl as ctrl'
       }
     },
     data: {pageTitle: 'Signature Search'}
   });
 }])
 
-// "controllerAs" syntax is not used here because we are using "$scope" to
-// watch the mlModel selected by user, and a combination of both seems weird.
-.controller('SignatureSearchCtrl', ['$scope', 'Signature', '$log', 'errGen',
-  function SignatureController($scope, Signature, $log, errGen) {
-    $scope.statusMessage = 'Machine learning model not selected yet.';
-    $scope.mlModel = null;
-    $scope.nameFilter = '';
+.controller('SignatureSearchCtrl', ['$stateParams', 'Signature', '$log',
+  'errGen',
+  function SignatureController($stateParams, Signature, $log, errGen) {
+    var self = this;
+    self.isValidModel = false;
+    // Do nothing if the model ID in URL is falsey. The error will be taken
+    // care of by "<ml-model-validator>" component.
+    if (!$stateParams.mlmodel) {
+      return;
+    }
 
-    $scope.$watch('mlModel', function() {
-      if ($scope.mlModel === null) { // Skip the initialization watch
-        return;
+    self.modelInUrl = $stateParams.mlmodel;
+    self.statusMessage = 'Connecting to the server ...';
+    self.nameFilter = '';
+
+    Signature.get(
+      {mlmodel: self.modelInUrl, limit: 0},
+      function success(response) {
+        self.signatures = response.objects;
+        self.signatures.sort(function(n1, n2) { // Sort signatures by name
+          if (n1.name < n2.name) {
+            return -1;
+          } else if (n1.name === n2.name) {
+            return 0;
+          }
+          return 1;
+        });
+        self.statusMessage = '';
+      },
+      function error(err) {
+        var message = errGen('Failed to get signatures: ', err);
+        $log.error(message);
+        self.statusMessage = message + '. Please try again later.';
       }
-      $scope.statusMessage = 'Connecting to the server ...';
-      var modelID = $scope.mlModel.id;
-      Signature.get(
-        {mlmodel: modelID, limit: 0},
-        function success(response) {
-          $scope.signatures = response.objects;
-          $scope.signatures.sort(function(n1, n2) { // Sort signatures by name
-            if (n1.name < n2.name) {
-              return -1;
-            } else if (n1.name === n2.name) {
-              return 0;
-            }
-            return 1;
-          });
-          $scope.statusMessage = '';
-        },
-        function error(err) {
-          var message = errGen('Failed to get signatures: ', err);
-          $log.error(message);
-          $scope.statusMessage = message + '. Please try again later.';
-        }
-      );
-    });
+    );
   }
 ]);

--- a/interface/src/app/signature/signature_search.tpl.html
+++ b/interface/src/app/signature/signature_search.tpl.html
@@ -1,28 +1,32 @@
-<h1>ADAGE: Search a Signature by Name</h1>
-
-<div class="well well-sm">
-  <h4>Machine Learning Model:</h4>
-  <ml-model-selector selected-ml-model="mlModel"></ml-model-selector>
+<div class="page-header">
+  <h1>ADAGE: Search Signature by Name</h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="ctrl.modelInUrl"
+                      is-valid-model="ctrl.isValidModel">
+  </ml-model-validator>
 </div>
 
-<h4 class="text-warning"  ng-bind="statusMessage"></h4>
+<div ng-if="ctrl.isValidModel">
+  <h4 class="text-warning" ng-bind="ctrl.statusMessage"></h4>
 
-<!-- We are using "ng-hide" (instead of "ng-if") here because we want to
-     keep the filter string when user selects another ML model. -->
-<div class="container" ng-hide="statusMessage">
-  <div class="row">
-    <div class="col-sm-3">
-      <h4><strong>Signatures in Selected Model:</strong></h4>
+  <!-- We are using "ng-hide" (instead of "ng-if") here because we want to
+       keep the filter string when user selects another ML model. -->
+  <div class="container" ng-hide="ctrl.statusMessage">
+    <div class="row">
+      <div class="col-sm-3">
+        <h4><strong>Signatures in Selected Model:</strong></h4>
+      </div>
+
+      <div class="col-sm-3">
+        <input class="form-control" placeholder="Filter"
+               ng-model="ctrl.nameFilter">
+      </div>
     </div>
 
-    <div class="col-sm-3">
-      <input class="form-control" placeholder="Filter"
-             ng-model="nameFilter">
+    <div class="col-sm-3"
+         ng-repeat="signature in ctrl.signatures
+                    | filter: {name: ctrl.nameFilter}">
+      <h4><a ui-sref="signature({id: signature.id})">{{signature.name}}</a></h4>
     </div>
-  </div>
-
-  <div class="col-sm-3"
-       ng-repeat="signature in signatures | filter: {name: nameFilter}">
-    <h4><a ui-sref="signature({id: signature.id})">{{signature.name}}</a></h4>
   </div>
 </div>

--- a/interface/src/app/signature/signature_search.tpl.html
+++ b/interface/src/app/signature/signature_search.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>ADAGE: Search Signature by Name</h1>
+  <h3>ADAGE: Search Signature by Name</h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="ctrl.modelInUrl"
                       is-valid-model="ctrl.isValidModel">

--- a/interface/src/app/utils.js
+++ b/interface/src/app/utils.js
@@ -20,7 +20,7 @@ angular.module('adage.utils', [])
 
 // Service of global machine learning model, which is shared by multiple
 // modules.
-.service('GlobalModelInfo', [function() {
+.service('MlModelTracker', [function() {
   this.init = function() {
     this.id = null;
     this.title = null;

--- a/interface/src/app/utils.js
+++ b/interface/src/app/utils.js
@@ -17,4 +17,24 @@ angular.module('adage.utils', [])
 
 // Number of digits in activity value shown on frontend:
 .constant('ActivityDigits', 5)
+
+// Service of global machine learning model, which is shared by multiple
+// modules.
+.service('GlobalModelInfo', [function() {
+  this.init = function() {
+    this.id = null;
+    this.title = null;
+    this.organism = null;
+  };
+
+  this.set = function(inputModel) {
+    if (this.id !== inputModel.id) {
+      this.id = inputModel.id || null;
+      this.title = inputModel.title || null;
+      this.organism = inputModel.organism || null;
+    }
+  };
+
+  this.init();
+}])
 ;

--- a/interface/src/app/volcano-plot/view.js
+++ b/interface/src/app/volcano-plot/view.js
@@ -29,6 +29,13 @@ angular.module('adage.volcano-plot.view', [
   //      to make a plot from those lists)
   function VolcanoPlotViewCtrl(SampleBin, $stateParams) {
     var ctrl = this;
+    ctrl.isValidModel = false;
+    // Do nothing if mlmodel in URL is falsey. The error will be taken
+    // care of by "<ml-model-validator>" component.
+    if (!$stateParams.mlmodel) {
+      return;
+    }
+
     this.mlModel = $stateParams.mlmodel;
     SampleBin.getVolcanoPlotData();
     this.sampleGroups = SampleBin.getSamplesByGroup();

--- a/interface/src/app/volcano-plot/view.tpl.html
+++ b/interface/src/app/volcano-plot/view.tpl.html
@@ -1,15 +1,23 @@
-<h1>Volcano Plot</h1>
-
-<div class="col-sm-8">
-  <volcano-plot
-    plot-data="ctrl.data"
-    on-click="ctrl.updateSelection(selectedSignatures)">
-  </volcano-plot>
+<div class="page-header">
+  <h1>Volcano Plot</h1>
+  <ml-model-view></ml-model-view>
+  <ml-model-validator model-id="ctrl.mlModel"
+                      is-valid-model="ctrl.isValidModel">
+  </ml-model-validator>
 </div>
-<div class="col-sm-4">
-  <volcano-plot-selection
-    ml-model="ctrl.mlModel"
-    selected-signatures="ctrl.selection"
-    sample-groups="ctrl.sampleGroups">
-  </volcano-plot-selection>
+
+<div ng-if="ctrl.isValidModel">
+  <div class="col-sm-8">
+    <volcano-plot
+       plot-data="ctrl.data"
+       on-click="ctrl.updateSelection(selectedSignatures)">
+    </volcano-plot>
+  </div>
+  <div class="col-sm-4">
+    <volcano-plot-selection
+       ml-model="ctrl.mlModel"
+       selected-signatures="ctrl.selection"
+       sample-groups="ctrl.sampleGroups">
+    </volcano-plot-selection>
+  </div>
 </div>

--- a/interface/src/app/volcano-plot/view.tpl.html
+++ b/interface/src/app/volcano-plot/view.tpl.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>Volcano Plot</h1>
+  <h3>Volcano Plot</h3>
   <ml-model-view></ml-model-view>
   <ml-model-validator model-id="ctrl.mlModel"
                       is-valid-model="ctrl.isValidModel">

--- a/interface/src/index.html
+++ b/interface/src/index.html
@@ -4,7 +4,7 @@
     <title ng-bind="pageTitle"></title>
 
     <!-- social media tags -->
-    <meta name="twitter:creator" content="@fg_tech">
+    <meta name="twitter:creator" content="@GreeneLab">
     <meta property="og:title" content="adage" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="http://adage.greenelab.com" />

--- a/interface/src/index.html
+++ b/interface/src/index.html
@@ -8,12 +8,14 @@
     <meta property="og:title" content="adage" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="http://adage.greenelab.com" />
-    <meta property="og:description" content="ADAGE: TODO: A description of the adage server and its purpose belongs here.">
+    <meta property="og:description"
+          content="ADAGE: A webserver for exploratory analyses guided by machine learning.">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- font awesome from BootstrapCDN -->
-    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.css" rel="stylesheet">
+    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.css"
+          rel="stylesheet">
 
     <!-- compiled CSS --><% styles.forEach( function ( file ) { %>
     <link rel="stylesheet" type="text/css" href="/static/<%= file %>" /><% }); %>
@@ -68,22 +70,25 @@
               </a>
             </li>
             <li ui-sref-active="active">
-              <a ui-sref="analyze">
-                Analyze
-              </a>
-            </li>
-            <li ui-sref-active="active">
               <a ui-sref="download">
                 Download
               </a>
             </li>
+            <li ui-sref-active="active">
+              <a ui-sref="analyze({mlmodel: modelInfo.id})"
+                 ng-show="modelInfo.title">
+                Analyze
+              </a>
+            </li>
             <li ng-class="{active: inGeneStates()}">
-              <a ui-sref="gene_search">
+              <a  ui-sref="gene_search({mlmodel: modelInfo.id})"
+                  ng-show="modelInfo.title">
                 GeneNetwork
               </a>
             </li>
             <li ng-class="{active: inSignatureStates()}">
-              <a ui-sref="signature_search">
+              <a ui-sref="signature_search({mlmodel: modelInfo.id})"
+                 ng-show="modelInfo.title">
                 Signature
               </a>
             </li>
@@ -98,6 +103,19 @@
             <profile-button ng-if="userObj"></profile-button>
           </ul>
         </div>
+
+        <!-- Current machine learning model
+        <div class="row">
+          <div class="col-sm-1"></div>
+          <div class="col-sm-11">
+            <span>Current Model: </span>
+            <span class="text-danger" ng-bind="modelInfo.title || 'Not Set'">
+            </span>
+            <span>(Click <a href="#/home">Home</a> to change)</span>
+          </div>
+        </div>
+        End of machine learning model info part
+        -->
       </div>
     </div>
 


### PR DESCRIPTION
This is by far the biggest PR that I have ever created in adage. It redesigns the workflow and forces users to select a valid machine learning model before any data can be displayed on the UI. The demo site is here:
http://165.123.67.202/#/home

Here is a summary of how this functionality is implemented (for reviewers who will read the code):

* A `MlModelTracker` service is defined in `app/utils.js` to keep track of currently selected machine learning model.

* To display the current machine learning model (which could be "unset") on web UI, a `mlModelView` component is defined in `app/mlmodel/mlModelComponents.js`. Note that it is for display ONLY.

* For URLs which include `mlmodel` parameter, the input `mlmodel` parameter is validated by another component `mlModelValidator`, which is defined in `app/mlmodel/mlModelComponents.js` too.

* Most HTML template files that are related to a ui-router state (except `Home`, `About`, `Download`, whose contents are static) are using `<ml-model-view>` tag to display the current model, and `<ml-model-validator>` tag to validate the `mlmodel` parameter in the URL. `signature.tpl.html` is another exception: it only uses  `<ml-model-view>`, because the URL doesn't need `mlmodel`. The input signature ID already determines the mlmodel.

* Any page that is using `<ml-model-validator>` also passes in a `isValidModel` boolean flag, which will be updated by  `<ml-model-validator>`. Initially the flag is false, if this flag is updated to true, then the input `mlmodel` is valid, and the other widgets in the HTML template will show up; otherwise these widgets will be hidden. That is why the main body of these HTML templates are enclosed by this:
```
<div ng-if="ctrl.isValidModel">
...
</div>
```

* I also cleaned up the HTML templates that correspond to the tabs on navbar so that their headers are all in this format:
```
<div class="page-header">
  <h1>Tab Title</h1>
  <ml-model-view>...</ml-model-view>
  <ml-model-validator ...></ml-model-validator>
</div> 
```
(As stated earlier, some pages don't have `<ml-model-view>` and `<ml-model-validator ...>` tags.)

If you have any questions or concerns, please let me know.
