### PR TITLE
Changing Signature page layout, switching to expandable sections

### DIFF
--- a/interface/src/app/signature/enriched_genesets.tpl.html
+++ b/interface/src/app/signature/enriched_genesets.tpl.html
@@ -1,12 +1,13 @@
 <h4>
-  <b>Enriched gene sets: </b>&nbsp;
-  <button type="button" class="btn btn-default"
-    ng-click="goToAnchor({anchor: 'top-of-page'})">
-    Back to Top
-  </button>
+  <b>Enriched gene sets: </b>
 </h4>
+<p>
+  Explore canonical (or curated) gene sets that significantly overlap
+  with this signature's associated genes; can help with interpretation of
+  the underlying process or processes.
+</p>
 
-<table id="enrichment-table" class="table table-striped table-bordered table-condensed">
+<table id="enrichment-table" class="table table-striped">
   <thead>
     <tr>
       <th>Pathways/Processes/Diseases</th>
@@ -16,11 +17,28 @@
     </tr>
   </thead>
 
-  <tr ng-repeat="geneset in enrichedGenesets">
+  <tr ng-repeat="geneset in enrichedGenesets | limitTo: numGenesetsShown">
     <td><a href="{{geneset.url}}">{{geneset.name}}</a></td>
     <td>{{geneset.dbase}}</td>
     <td>{{geneset.pValue}}</td>
     <td>{{geneset.genes}}</td>
+  </tr>
+
+  <tr ng-click="setMode()" ng-show="topMode">
+    <td>
+      <button type="button" class="btn btn-default">Show all ...</button>
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr ng-click="setMode()" ng-hide="topMode">
+    <td>
+      <button type="button" class="btn btn-default">Only show top {{topNum}}</button>
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
   </tr>
 
 </table>

--- a/interface/src/app/signature/enriched_genesets.tpl.html
+++ b/interface/src/app/signature/enriched_genesets.tpl.html
@@ -1,5 +1,9 @@
 <h4>
-  <b>Enriched gene sets: </b>
+  <b>Enriched gene sets: </b>&nbsp;
+  <button type="button" class="btn btn-default"
+    ng-click="goToAnchor({anchor: 'top-of-page'})">
+    Back to Top
+  </button>
 </h4>
 
 <table id="enrichment-table" class="table table-striped table-bordered table-condensed">

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -1,6 +1,10 @@
 <div ng-if="!queryStatus">
   <h4>
-    <b>Experiments with the Highest Range: </b>
+    <b>Experiments with the Highest Range: </b>&nbsp;
+    <button type="button" class="btn btn-default"
+      ng-click="goToAnchor({anchor: 'top-of-page'})">
+      Back to Top
+    </button>
   </h4>
   <button class="btn btn-primary" ng-click="setMode()"
           ng-hide="topMode">Show Top {{topNum}}</button>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -5,7 +5,7 @@
   <p>
     Explore gene expression experiments with the highest range of this
     signature's activity. Click the activity distribution widget to see sample
-    annotations in this experiement.
+    annotations in this experiment.
   </p>
   <table class="table table-striped">
     <tbody>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -1,23 +1,17 @@
 <div ng-if="!queryStatus">
   <h4>
-    <b>Experiments with the Highest Range: </b>&nbsp;
-    <button type="button" class="btn btn-default"
-      ng-click="goToAnchor({anchor: 'top-of-page'})">
-      Back to Top
-    </button>
+    <b>Experiments with the Highest Range: </b>
   </h4>
-  <button class="btn btn-primary" ng-click="setMode()"
-          ng-hide="topMode">Show Top {{topNum}}</button>
-  <button class="btn btn-primary" ng-click="setMode()"
-          ng-show="topMode">Show All</button>
-
-  <br>
+  <p>
+    Explore gene expression experiments with the highest range of this
+    signature's activity.
+  </p>
   (Click the activity distribution widget to see sample annotations in this experiement.)
   <table class="table table-striped">
     <tbody>
       <!-- It may seem more intuitive to use:
              <tr ng-repeat="exp in experiments | limitTo: numExpShown">
-           but this approach would require re-rendering the vega-lite widget;
+           but this approach would require re-r.endering the vega-lite widget;
            instead we use "$index >= numExpShown" to hide rows of lower range.
          -->
       <tr ng-repeat="exp in experiments" ng-show="$index < numExpShown">
@@ -42,6 +36,16 @@
                  tooltip-placement="left-top">
             </div>
           </a>
+        </td>
+      </tr>
+      <tr ng-click="setMode()" ng-show="topMode">
+        <td>
+          <button type="button" class="btn btn-default">Show all ...</button>
+        </td>
+      </tr>
+      <tr ng-click="setMode()" ng-hide="topMode">
+        <td>
+          <button type="button" class="btn btn-default">Only show top {{topNum}}</button>
         </td>
       </tr>
     </tbody>

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -4,9 +4,9 @@
   </h4>
   <p>
     Explore gene expression experiments with the highest range of this
-    signature's activity.
+    signature's activity. Click the activity distribution widget to see sample
+    annotations in this experiement.
   </p>
-  (Click the activity distribution widget to see sample annotations in this experiement.)
   <table class="table table-striped">
     <tbody>
       <!-- It may seem more intuitive to use:

--- a/interface/src/app/signature/high_range_exp.tpl.html
+++ b/interface/src/app/signature/high_range_exp.tpl.html
@@ -11,7 +11,7 @@
     <tbody>
       <!-- It may seem more intuitive to use:
              <tr ng-repeat="exp in experiments | limitTo: numExpShown">
-           but this approach would require re-r.endering the vega-lite widget;
+           but this approach would require re-rendering the vega-lite widget;
            instead we use "$index >= numExpShown" to hide rows of lower range.
          -->
       <tr ng-repeat="exp in experiments" ng-show="$index < numExpShown">

--- a/interface/src/app/signature/participatory_genes.tpl.html
+++ b/interface/src/app/signature/participatory_genes.tpl.html
@@ -15,10 +15,25 @@
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="gene in genes | orderBy: 'sysName'">
+      <tr ng-repeat="gene in genes | orderBy: 'sysName' | limitTo: numGenesShown">
         <td><b>{{gene.sysName}}</b></td>
         <td>{{gene.stdName}}</td>
         <td>{{gene.desc}}</td>
+      </tr>
+
+      <tr ng-click="setMode()" ng-show="topMode">
+        <td>
+          <button type="button" class="btn btn-default">Show all ...</button>
+        </td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr ng-click="setMode()" ng-hide="topMode">
+        <td>
+          <button type="button" class="btn btn-default">Only show {{topNum}}</button>
+        </td>
+        <td></td>
+        <td></td>
       </tr>
     </tbody>
   </table>

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -26,9 +26,9 @@ angular.module('adage.signature', [
 
 
 .controller('SignatureCtrl', ['Signature', '$stateParams', 'MlModelTracker',
-  '$log', 'errGen',
+  '$log', 'errGen', '$location', '$anchorScroll',
   function SignatureController(Signature, $stateParams, MlModelTracker, $log,
-                               errGen) {
+                               errGen, $location, $anchorScroll) {
     var self = this;
     if (!$stateParams.id) {
       self.statusMessage = 'Please specify signature ID in the URL.';
@@ -36,6 +36,12 @@ angular.module('adage.signature', [
     }
     self.id = $stateParams.id;
     self.statusMessage = 'Connecting to the server ...';
+
+    self.goToAnchor = function(anchorName) {
+      $location.hash(anchorName);
+      $anchorScroll();
+    };
+
     Signature.get(
       {id: self.id},
       function success(response) {

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -26,9 +26,9 @@ angular.module('adage.signature', [
 
 
 .controller('SignatureCtrl', ['Signature', '$stateParams', 'MlModelTracker',
-  '$log', 'errGen', '$location', '$anchorScroll',
+  '$log', 'errGen',
   function SignatureController(Signature, $stateParams, MlModelTracker, $log,
-                               errGen, $location, $anchorScroll) {
+                               errGen) {
     var self = this;
     if (!$stateParams.id) {
       self.statusMessage = 'Please specify signature ID in the URL.';
@@ -36,11 +36,6 @@ angular.module('adage.signature', [
     }
     self.id = $stateParams.id;
     self.statusMessage = 'Connecting to the server ...';
-
-    self.goToAnchor = function(anchorObj) {
-      $location.hash(anchorObj.anchor);
-      $anchorScroll();
-    };
 
     Signature.get(
       {id: self.id},

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -37,8 +37,8 @@ angular.module('adage.signature', [
     self.id = $stateParams.id;
     self.statusMessage = 'Connecting to the server ...';
 
-    self.goToAnchor = function(anchorName) {
-      $location.hash(anchorName);
+    self.goToAnchor = function(anchorObj) {
+      $location.hash(anchorObj.anchor);
       $anchorScroll();
     };
 
@@ -187,7 +187,8 @@ angular.module('adage.signature', [
       scope: {
         modelId: '@',
         signatureId: '@',
-        inputTopNum: '@topExp'
+        inputTopNum: '@topExp',
+        goToAnchor: '&'
       },
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';
@@ -322,7 +323,8 @@ angular.module('adage.signature', [
       scope: {
         organism: '@',
         selectedParticipationType: '=',
-        genes: '=' // an array of high-weight genes in the Signature page.
+        genes: '=', // an array of high-weight genes in the Signature page.
+        goToAnchor: '&'
       },
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -36,7 +36,6 @@ angular.module('adage.signature', [
     }
     self.id = $stateParams.id;
     self.statusMessage = 'Connecting to the server ...';
-
     Signature.get(
       {id: self.id},
       function success(response) {

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -77,6 +77,17 @@ angular.module('adage.signature', [
       },
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';
+
+        $scope.topMode = true;
+        $scope.topNum = 3;
+        $scope.numGenesShown = $scope.topNum;
+
+        $scope.setMode = function() {
+          $scope.topMode = !$scope.topMode;
+          $scope.numGenesShown =
+            $scope.topMode ? $scope.topNum : $scope.genes.length;
+        };
+
         $scope.$watch('selectedParticipationType', function() {
           if ($scope.selectedParticipationType) {
             Participation.get(
@@ -187,8 +198,7 @@ angular.module('adage.signature', [
       scope: {
         modelId: '@',
         signatureId: '@',
-        inputTopNum: '@topExp',
-        goToAnchor: '&'
+        inputTopNum: '@topExp'
       },
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';
@@ -323,11 +333,20 @@ angular.module('adage.signature', [
       scope: {
         organism: '@',
         selectedParticipationType: '=',
-        genes: '=', // an array of high-weight genes in the Signature page.
-        goToAnchor: '&'
+        genes: '=' // an array of high-weight genes in the Signature page.
       },
       link: function($scope) {
         $scope.queryStatus = 'Connecting to the server ...';
+
+        $scope.topMode = true;
+        $scope.topNum = 3;
+        $scope.numGenesetsShown = $scope.topNum;
+
+        $scope.setMode = function() {
+          $scope.topMode = !$scope.topMode;
+          $scope.numGenesetsShown =
+            $scope.topMode ? $scope.topNum : $scope.enrichedGenesets.length;
+        };
 
         $scope.pValueCutoff = 0.05;
         var pValueSigDigits = 3;

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -6,64 +6,37 @@
 <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
 
 <p>
-  <b>Gene Participation Type:</b>
+  <b>Participation Type of Genes in this Signature:</b>
   <br>
   <participation-type-selector
     selected-participation-type="ctrl.selectedParticipationType">
   </participation-type-selector>
   <br>
-  <br>
-  <b>Description:</b>
-  <br>
   {{ctrl.selectedParticipationType.description}}
 </p>
-
-<hr>
+<br>
 
 <div ng-if="!ctrl.statusMessage">
-  <h4><b>Sections:</b></h4>
-  <li role="presentation">
-    <a ng-click="ctrl.goToAnchor({anchor: 'participatory-genes'})">
-      {{ctrl.selectedParticipationType.name}}
-    </a>
-  </li>
-  <li role="presentation">
-    <a ng-click="ctrl.goToAnchor({anchor: 'high-range-exp'})">
-      High range experiments
-    </a>
-  </li>
-  <li role="presentation">
-    <a ng-click="ctrl.goToAnchor({anchor: 'enriched-genesets'})">
-      Enriched gene sets
-    </a>
-  </li>
-  <br>
-
   <div class="container">
     <participatory-genes
       signature-id="{{ctrl.id}}"
       genes="ctrl.genes"
-      selected-participation-type="ctrl.selectedParticipationType"
-      id="participatory-genes">
+      selected-participation-type="ctrl.selectedParticipationType">
     </participatory-genes>
-    <hr>
-
-    <high-range-exp
-      signature-id="{{ctrl.id}}"
-      model-id="{{ctrl.modelID}}"
-      top-exp="20"
-      id="high-range-exp"
-      go-to-anchor="ctrl.goToAnchor({anchor: anchor})">
-    </high-range-exp>
     <hr>
 
     <enriched-genesets
       organism="{{ctrl.organism}}"
       genes="ctrl.genes"
-      selected-participation-type="ctrl.selectedParticipationType"
-      id="enriched-genesets"
-      go-to-anchor="ctrl.goToAnchor({anchor: anchor})">
+      selected-participation-type="ctrl.selectedParticipationType">
     </enriched-genesets>
+    <hr>
+
+    <high-range-exp
+      signature-id="{{ctrl.id}}"
+      model-id="{{ctrl.modelID}}"
+      top-exp="3">
+    </high-range-exp>
 
   </div>
 </div>

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -1,4 +1,4 @@
-<div class="page-header" id="top-of-page">
+<div class="page-header">
   <h3>Signature: {{ctrl.name}}</h3>
   <ml-model-view></ml-model-view>
 </div>

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -36,7 +36,7 @@
       </li>
       <li role="presentation">
         <a ng-click="ctrl.goToAnchor('enriched-genesets')">
-          Enriched genesets
+          Enriched gene sets
         </a>
       </li>
     </ul>

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -1,4 +1,4 @@
-<div class="page-header">
+<div class="page-header" id="top-of-page">
   <h3>Signature: {{ctrl.name}}</h3>
   <ml-model-view></ml-model-view>
 </div>
@@ -21,26 +21,23 @@
 <hr>
 
 <div ng-if="!ctrl.statusMessage">
-  <div class="container">
-    <b>Sections:</b>
-    <ul class="nav nav-pills">
-      <li role="presentation">
-        <a ng-click="ctrl.goToAnchor('participatory-genes')">
-          {{ctrl.selectedParticipationType.name}}
-        </a>
-      </li>
-      <li role="presentation">
-        <a ng-click="ctrl.goToAnchor('high-range-exp')">
-          High range experiments
-        </a>
-      </li>
-      <li role="presentation">
-        <a ng-click="ctrl.goToAnchor('enriched-genesets')">
-          Enriched gene sets
-        </a>
-      </li>
-    </ul>
-  </div>
+  <h4><b>Sections:</b></h4>
+  <li role="presentation">
+    <a ng-click="ctrl.goToAnchor({anchor: 'participatory-genes'})">
+      {{ctrl.selectedParticipationType.name}}
+    </a>
+  </li>
+  <li role="presentation">
+    <a ng-click="ctrl.goToAnchor({anchor: 'high-range-exp'})">
+      High range experiments
+    </a>
+  </li>
+  <li role="presentation">
+    <a ng-click="ctrl.goToAnchor({anchor: 'enriched-genesets'})">
+      Enriched gene sets
+    </a>
+  </li>
+  <br>
 
   <div class="container">
     <participatory-genes
@@ -55,7 +52,8 @@
       signature-id="{{ctrl.id}}"
       model-id="{{ctrl.modelID}}"
       top-exp="20"
-      id="high-range-exp">
+      id="high-range-exp"
+      go-to-anchor="ctrl.goToAnchor({anchor: anchor})">
     </high-range-exp>
     <hr>
 
@@ -63,7 +61,8 @@
       organism="{{ctrl.organism}}"
       genes="ctrl.genes"
       selected-participation-type="ctrl.selectedParticipationType"
-      id="enriched-genesets">
+      id="enriched-genesets"
+      go-to-anchor="ctrl.goToAnchor({anchor: anchor})">
     </enriched-genesets>
 
   </div>

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -21,34 +21,50 @@
 <hr>
 
 <div ng-if="!ctrl.statusMessage">
+  <div class="container">
+    <b>Sections:</b>
+    <ul class="nav nav-pills">
+      <li role="presentation">
+        <a ng-click="ctrl.goToAnchor('participatory-genes')">
+          {{ctrl.selectedParticipationType.name}}
+        </a>
+      </li>
+      <li role="presentation">
+        <a ng-click="ctrl.goToAnchor('high-range-exp')">
+          High range experiments
+        </a>
+      </li>
+      <li role="presentation">
+        <a ng-click="ctrl.goToAnchor('enriched-genesets')">
+          Enriched genesets
+        </a>
+      </li>
+    </ul>
+  </div>
 
   <div class="container">
-    <div class="row">
-      <div class="col-xs-6">
-        <participatory-genes
-          signature-id="{{ctrl.id}}"
-          genes="ctrl.genes"
-          selected-participation-type="ctrl.selectedParticipationType">
-        </participatory-genes>
-      </div>
+    <participatory-genes
+      signature-id="{{ctrl.id}}"
+      genes="ctrl.genes"
+      selected-participation-type="ctrl.selectedParticipationType"
+      id="participatory-genes">
+    </participatory-genes>
+    <hr>
 
-      <div class="col-xs-6">
-        <high-range-exp signature-id="{{ctrl.id}}" model-id="{{ctrl.modelID}}"
-                        top-exp="20">
-        </high-range-exp>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-xs-6">
-        <enriched-genesets
-          organism="{{ctrl.organism}}"
-          genes="ctrl.genes"
-          selected-participation-type="ctrl.selectedParticipationType">
-        </enriched-genesets>
-      </div>
+    <high-range-exp
+      signature-id="{{ctrl.id}}"
+      model-id="{{ctrl.modelID}}"
+      top-exp="20"
+      id="high-range-exp">
+    </high-range-exp>
+    <hr>
 
-      <div class="col-xs-6">
-      </div>
-    </div>
+    <enriched-genesets
+      organism="{{ctrl.organism}}"
+      genes="ctrl.genes"
+      selected-participation-type="ctrl.selectedParticipationType"
+      id="enriched-genesets">
+    </enriched-genesets>
+
   </div>
 </div>


### PR DESCRIPTION
Removing the grid-like structure of the Signature page, and instead putting the three existing directives into consecutive sections, and adding anchors to them. Also adding links that take the users to these anchors using Angular's '$location.hash()' and '$anchorScroll'. This PR addresses issue #131 

The Signature page now looks like this: http://165.123.67.154:8000/#/signature/404
Let me know how it looks!