### PR TITLE
Changing header of ParticipationType selector in signature page to read 'Filter genes in this signature by:'.

### DIFF
--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -6,7 +6,9 @@
 <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
 
 <p>
-  <b>Filter genes in this signature by:</b>
+  Each signature is comprised of genes with varying importance. Different
+  methods can be used to find the most relevant set of genes.
+  <b>Filter genes in this signature using:</b>
   <br>
   <participation-type-selector
     selected-participation-type="ctrl.selectedParticipationType">

--- a/interface/src/app/signature/signature.tpl.html
+++ b/interface/src/app/signature/signature.tpl.html
@@ -6,7 +6,7 @@
 <h3 class="text-warning" ng-bind="ctrl.statusMessage"></h3>
 
 <p>
-  <b>Participation Type of Genes in this Signature:</b>
+  <b>Filter genes in this signature by:</b>
   <br>
   <participation-type-selector
     selected-participation-type="ctrl.selectedParticipationType">


### PR DESCRIPTION
This makes the meaning of it more obvious to new users. Example of this new UI is running at: http://165.123.67.154:8000/#/signature/100