### PR TITLE
Fix of Issue #184

### DIFF
--- a/adage/analyze/management/commands/add_ml_model.py
+++ b/adage/analyze/management/commands/add_ml_model.py
@@ -6,7 +6,7 @@ name is ml_model_name into the database's ml_model table.  It should be
 invoked like this:
 
   python manage.py add_ml_model <ml_model_name> <organism_tax_id> \
- [--directed_edge] --g2g_edge_cutoff <cutoff_value>
+ [--directed_edge] [--g2g_edge_cutoff <cutoff_value>]
 
 The two required arguments are:
   (1) ml_model_name: machine learning model name;

--- a/adage/analyze/management/commands/add_ml_model.py
+++ b/adage/analyze/management/commands/add_ml_model.py
@@ -6,7 +6,7 @@ name is ml_model_name into the database's ml_model table.  It should be
 invoked like this:
 
   python manage.py add_ml_model <ml_model_name> <organism_tax_id> \
- [--directed_edge]
+ [--directed_edge] --g2g_edge_cutoff <cutoff_value>
 
 The two required arguments are:
   (1) ml_model_name: machine learning model name;
@@ -15,6 +15,10 @@ The two required arguments are:
 "--directed_edge" is an optional argument.  If it is specified, the
 edges in the gene-gene relationship table will be directed; otherwise
 the edges in the gene-gene relationship table will be undirected.
+
+"--g2g_edge_cutoff" is another optional argument.  If it is specified,
+the numeric value that follows will be the cutoff value of the edges in
+gene-gene network; otherwise the edge cutoff value will be set to 0.
 
 IMPORTANT:
 Before running this command, please make sure that organism_tax_id
@@ -42,12 +46,18 @@ class Command(BaseCommand):
                             default=False,
                             help='Create directed gene-gene relationship '
                             'edges')
+        parser.add_argument('--g2g_edge_cutoff',
+                            type=float,
+                            dest='g2g_edge_cutoff',
+                            default=0.0,
+                            help='Gene-gene network edge cutoff value')
 
     def handle(self, **options):
         try:
             add_ml_model(options['ml_model_name'],
                          options['organism_tax_id'],
-                         options['directed'])
+                         options['directed'],
+                         options['g2g_edge_cutoff'])
             self.stdout.write(self.style.NOTICE(
                 "Added a new machine learning model successfully"))
         except Exception as e:
@@ -56,7 +66,7 @@ class Command(BaseCommand):
                 "raised an exception:\n%s" % e)
 
 
-def add_ml_model(ml_model_name, organism_tax_id, directed_edge):
+def add_ml_model(ml_model_name, organism_tax_id, directed_edge, edge_cutoff):
     # Raise an exception if ml_model_name on the command line is "" or
     # "  ".
     if not ml_model_name or ml_model_name.isspace():
@@ -74,4 +84,5 @@ def add_ml_model(ml_model_name, organism_tax_id, directed_edge):
 
     MLModel.objects.create(title=ml_model_name,
                            organism=organism,
-                           directed_g2g_edge=directed_edge)
+                           directed_g2g_edge=directed_edge,
+                           g2g_edge_cutoff=edge_cutoff)

--- a/adage/analyze/migrations/0012_mlmodel_g2g_edge_cutoff.py
+++ b/adage/analyze/migrations/0012_mlmodel_g2g_edge_cutoff.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analyze', '0011_auto_20170505_1627'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mlmodel',
+            name='g2g_edge_cutoff',
+            field=models.FloatField(default=0.0),
+        ),
+    ]

--- a/adage/analyze/models.py
+++ b/adage/analyze/models.py
@@ -148,6 +148,7 @@ class MLModel(models.Model):
     # edges (see "Edge" model below) are directed or not. Default is
     # False (not directed).
     directed_g2g_edge = models.BooleanField(default=False)
+    g2g_edge_cutoff = models.FloatField(default=0.0)
 
     def __unicode__(self):
         edge_info = "directed" if self.directed_g2g_edge else "undirected"

--- a/fabfile/adage_server.py
+++ b/fabfile/adage_server.py
@@ -169,7 +169,8 @@ def import_data_and_index():
     run('python manage.py organisms_create_or_update --taxonomy_id=208964 '
         '--scientific_name="Pseudomonas aeruginosa" '
         '--common_name="Pseudomonas aeruginosa"')
-    run('python manage.py add_ml_model "Ensemble ADAGE 300" 208964')
+    run('python manage.py add_ml_model "Ensemble ADAGE 300" 208964 '
+        '--g2g_edge_cutoff 0.4')
     # import activity data
     run('python manage.py import_activity "%s" "Ensemble ADAGE 300"' %
         CONFIG['data']['activity_file'])

--- a/interface/bower.json
+++ b/interface/bower.json
@@ -21,7 +21,7 @@
     "ng-sortable": "~1.3.6",
     "ng-vega": "^1.4.0",
     "d3-tip": "~0.7.1",
-    "angularjs-slider": "^5.8.1",
+    "angularjs-slider": "^6.2.3",
     "vega-lite": "^1.3.1",
     "vega-embed": "^2.2.0"
   },

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -65,13 +65,15 @@ angular.module('adage.gene.network', [
 
 .controller('GeneNetworkCtrl',
   ['$stateParams', 'Edge', 'Signature', 'Gene', 'ExpressionValue', '$log',
-    'errGen', '$httpParamSerializerJQLike',
+    'errGen', '$httpParamSerializerJQLike', '$scope', 'MlModelTracker',
+    '$timeout',
     function GeneNetworkController(
       $stateParams, Edge, Signature, Gene, ExpressionValue, $log, errGen,
-      $httpParamSerializerJQLike
+      $httpParamSerializerJQLike, $scope, MlModelTracker, $timeout
     ) {
       var self = this;
       self.isValidModel = false;
+
       // Do nothing if mlmodel in URL is falsey. The error will be taken
       // care of by "<ml-model-validator>" component.
       if (!$stateParams.mlmodel) {
@@ -134,21 +136,45 @@ angular.module('adage.gene.network', [
       };
 
       self.slider = {  // range slider configuration
-        min: 0,                    // initial position of slider on the left
-        max: maxCorrelation,       // initial position of slider on the right
+        min: 0,                  // initial position of slider on the left
+        max: maxCorrelation,     // initial position of slider on the right
         options: {
-          floor: 0,                // minimum of the slider bar
-          ceil: maxCorrelation,    // maximum of the slider bar
+          floor: 0,              // minimum of the slider bar
+          ceil: maxCorrelation,  // maximum of the slider bar
           step: 0.01,
           precision: 2,
-          showTicks: 0.5,
-          showTicksValues: true,
           noSwitching: true,
           onEnd: function(id, low, high) {
             self.renderNetwork();
           }
         }
       };
+
+      // After machine learning model in the URL has been validated,
+      // reconfigure the slider and force render it. See the discussion at:
+      // https://github.com/angular-slider/angularjs-slider/issues/79#issuecomment-219213647
+      // (Also tried $scope.$$postDigest, not work.)
+      var refreshSlider = function() {
+        $timeout(function() {
+          $scope.$broadcast('rzSliderForceRender');
+        }, 250);
+        // Note by dhu: 250ms is an arbitrary timeout value. The minimum timeout
+        // value that worked on my desktop is 150ms.
+      };
+      // Monitor "self.isValidModel". Once it is true, reconfigure a few slider
+      // parameters and call refreshSlider().
+      $scope.$watch(
+        function() {
+          return self.isValidModel;
+        },
+        function() {
+          if (self.isValidModel) {
+            self.slider.min = MlModelTracker.g2gEdgeCutoff;
+            self.slider.options.floor = MlModelTracker.g2gEdgeCutoff;
+            refreshSlider();
+          }
+        }
+      );
 
       // Function that returns unique numerical gene IDs included in the URL.
       var getGenesInURL = function(genesParam) {

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -152,7 +152,7 @@ angular.module('adage.gene.network', [
 
       // After machine learning model in the URL has been validated,
       // reconfigure the slider and force render it. See the discussion at:
-      // https://github.com/angular-slider/angularjs-slider/issues/79#issuecomment-219213647
+      // https://github.com/angular-slider/angularjs-slider/issues/79#issuecomment-225438841
       // (Also tried $scope.$$postDigest, not work.)
       var refreshSlider = function() {
         $timeout(function() {

--- a/interface/src/app/utils.js
+++ b/interface/src/app/utils.js
@@ -25,6 +25,7 @@ angular.module('adage.utils', [])
     this.id = null;
     this.title = null;
     this.organism = null;
+    this.g2gEdgeCutoff = null;
   };
 
   this.set = function(inputModel) {
@@ -32,6 +33,7 @@ angular.module('adage.utils', [])
       this.id = inputModel.id || null;
       this.title = inputModel.title || null;
       this.organism = inputModel.organism || null;
+      this.g2gEdgeCutoff = inputModel.g2g_edge_cutoff;
     }
   };
 


### PR DESCRIPTION
This PR includes two parts:

* On the back end:
(1) Add a `g2g_edge_cutoff` field in **MLModel** class;
(2) Created a DB migration file for the new MLModel;
(3) Modified the management command that creates a new machine learning model;
(4) Modified the deployment fabric file.

* On the front end:
(1) Set the cutoff value in `MlModelTracker` service;
(2) Updated the angularjs-slider version in bower.
(3) Set the slider's minimum value when the machine learning model in URL is validated.

The code for the front end change is not as simple as I thought (which is one reason why I updated `angularjs-slider` package). I found the solution by digging into one of the issues in angularjs github. I hope in the later version the author can figure out a better way to update the slider.