### PR TITLE
Adding changes needed to break off Elasticsearch and run it in its own container.

### DIFF
--- a/adage/requirements.txt
+++ b/adage/requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.2.1
 Django==1.8.11
 django-fixtureless==1.4.3.3
-django-haystack==2.4.1
+django-haystack==2.6.0
 django-tastypie==0.13.3
 elasticsearch==1.9.0
 gunicorn==19.4.5

--- a/docker_local_deploy.sh
+++ b/docker_local_deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# TODO: *Note - This script is a stub, and we will be adding the steps needed
+# to run a local deployment during the month of August, 2017.
+
+# Bash script to do a local deploy of the adage web server using Docker
+
+# Pull the Docker Elasticsearch image for version 2.3, and run it (detached)
+# locally, making port 9200 accessible.
+#
+# *Note: We are using Elasticsearch version 2.x because django-haystack,
+# one of our dependencies, only supports Elasticsearch versions
+# 1.x and 2.x, not the newer versions (as of 8/7/17). See:
+# http://django-haystack.readthedocs.io/en/v2.6.0/installing_search_engines.html#elasticsearch
+#
+# Also, we are using Elasticsearch v2.3 (even though v2.4.6 is
+# available) because it is the highest version that AWS supports of the
+# 2.x major version (as of 8/7/17). The logic here is that we want the local
+# deployment to mirror our deployment on AWS. See:
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-gsg.html
+docker pull library/elasticsearch:2.3
+docker run -d -p 9200:9200 elasticsearch:2.3


### PR DESCRIPTION
Resolves Issue #216 

Upgrading django-haystack version to 2.6.0 in requirements.txt (as it is needed for Elasticsearch v2.x), and adding a stub for the steps needed to run a local deployment of this webserver. This stub right now contains the commands to pull the appropriate Elasticsearch Docker image and run it so that the django project can access it.