### PR TITLE
Gene-Gene Network: Remove max slider from slider bar

### DIFF
--- a/adage/analyze/api.py
+++ b/adage/analyze/api.py
@@ -281,6 +281,7 @@ class NodeResource(ModelResource):
             'heavy_genes': ('exact', ),  # New filter, see apply_filters().
             'mlmodel': ('exact', ),
         }
+        ordering = ['name']
 
     def prepend_urls(self):
         return [

--- a/interface/src/app/gene/network/network.js
+++ b/interface/src/app/gene/network/network.js
@@ -130,21 +130,20 @@ angular.module('adage.gene.network', [
         } else {
           correlationSign = 1;
         }
-        network.filterEdgeWeight(self.slider.min, self.slider.max,
+        network.filterEdgeWeight(self.slider.min, maxCorrelation,
                                  correlationSign);
         network.draw();
       };
 
       self.slider = {  // range slider configuration
         min: 0,                  // initial position of slider on the left
-        max: maxCorrelation,     // initial position of slider on the right
         options: {
           floor: 0,              // minimum of the slider bar
           ceil: maxCorrelation,  // maximum of the slider bar
           step: 0.01,
           precision: 2,
-          noSwitching: true,
-          onEnd: function(id, low, high) {
+          showSelectionBarEnd: true,
+          onEnd: function() {
             self.renderNetwork();
           }
         }
@@ -329,6 +328,7 @@ angular.module('adage.gene.network', [
           Signature.get(
             {'heavy_genes': heavyGenes,
               'mlmodel': MlModelTracker.id,
+              'order_by': 'name',
               'limit': 0
             },
             function success(response) {

--- a/interface/src/app/gene/network/network.tpl.html
+++ b/interface/src/app/gene/network/network.tpl.html
@@ -31,7 +31,6 @@
       </label>
     </form>
     <rzslider rz-slider-model="ctrl.slider.min"
-              rz-slider-high="ctrl.slider.max"
               rz-slider-options="ctrl.slider.options">
     </rzslider>
   </div>


### PR DESCRIPTION
This is a fix for issue #257. I also tweaked the back end so that the signature names on edge tips window will be displayed in the alphabetic order of the signature names (which is consistent to the order on main page of signatures). 

Here is a demo page for this PR:
http://165.123.67.202/#/gene_network/?genes=6552&mlmodel=4