### PR TITLE
Rename "node" to "signature" (Fix of Issue #138)

### DIFF
--- a/adage/adage/urls.py
+++ b/adage/adage/urls.py
@@ -20,7 +20,7 @@ from organisms.api import OrganismResource
 from genes.api import GeneResource
 from analyze.api import (SearchResource, ExperimentResource,
                          AnnotationTypeResource, SampleResource,
-                         MLModelResource, NodeResource, ActivityResource,
+                         MLModelResource, SignatureResource, ActivityResource,
                          EdgeResource, ParticipationTypeResource,
                          ParticipationResource, ExpressionValueResource)
 
@@ -32,7 +32,7 @@ v0_api.register(SampleResource())
 v0_api.register(OrganismResource())
 v0_api.register(GeneResource())
 v0_api.register(MLModelResource())
-v0_api.register(NodeResource())
+v0_api.register(SignatureResource())
 v0_api.register(ActivityResource())
 v0_api.register(EdgeResource())
 v0_api.register(ParticipationTypeResource())

--- a/adage/analyze/management/commands/create_or_update_participation_type.py
+++ b/adage/analyze/management/commands/create_or_update_participation_type.py
@@ -6,7 +6,7 @@ argument and the second is the 'description' argument.
 
 Example usage:
 python manage.py create_or_update_participation_type "High-weight genes" \
-    "High-weight genes are those that most strongly influence the node's ..."
+    "High-weight genes are those that most strongly influence ..."
 """
 
 from __future__ import print_function
@@ -20,7 +20,7 @@ logger.addHandler(logging.NullHandler())
 
 class Command(BaseCommand):
     help = ("Creates a participation type in the database for the "
-            "participation of genes in a node.")
+            "participation of genes in a signature.")
 
     def add_arguments(self, parser):
         parser.add_argument('name', type=str)

--- a/adage/analyze/management/commands/import_activity.py
+++ b/adage/analyze/management/commands/import_activity.py
@@ -78,7 +78,7 @@ def import_activity(file_handle, ml_model_name):
 
 def import_signatures(signatures, mlmodel):
     """
-    Load input signatures into "Signaturee" table in the database.
+    Load input signatures into "Signature" table in the database.
 
     This function will raise an exception if any of the following errors
     are detected:

--- a/adage/analyze/management/commands/import_gene_network.py
+++ b/adage/analyze/management/commands/import_gene_network.py
@@ -9,8 +9,8 @@ tab-delimited and each line should include 4 columns:
   (4) Sign of the weight (either "+" or "-").
 
 The file's first line will be ignored because it only has column names.
-Here is an example input file:
-  adage-server/data/eADAGE_net300_allNodes_ADAGEnet_PAID_corCutoff0.4.txt
+Here is a gzipped example input file:
+  adage-server/data/gene_gene_network_cutoff_0.2.txt.gz
 
 The command requires two arguments:
   (1) gene_network_file: the name of input gene-gene network file;

--- a/adage/analyze/management/commands/import_signature_gene_network.py
+++ b/adage/analyze/management/commands/import_signature_gene_network.py
@@ -1,27 +1,29 @@
 """
-This management command will read an input node-gene network file and
+This management command will read an input signature-gene network file and
 populate the "Participation" table in the database.  A valid input file
-must be tab-delimited and each line must start with a valid node name,
-followed by systematic names of genes that are related to this node.
+must be tab-delimited and each line must start with a valid signaure name,
+followed by systematic names of genes that are related to this signature.
 
 Here is an example input file:
-  adage-server/data/node_gene_network.txt
+  adage-server/data/signature_gene_network.txt
 
 The command requires three arguments:
-  (1) node_gene_network_file: the name of input node-gene network file;
-  (2) ml_model_name: the name of machine learning model of the nodes in
-      node_gene_network_file. (This argument is needed because a node's
-      name may not be unique in the database, but its name and ml_model
-      are unique together.)
+  (1) signature_gene_network_file: the name of input signature-gene network
+      file;
+  (2) ml_model_name: the name of machine learning model of the signatures in
+      signature_gene_network_file. (This argument is needed because a
+      signature's name may not be unique in the database, but its name and
+      ml_model are unique together.)
   (3) participation_type_name: the name of the type of participation of
-      the genes in the nodes. A couple of examples are:
+      the genes in the signatures. A couple of examples are:
       "High weight genes", and "PatternMarker".
 
 
-For example, to import the data lines in an input file "node_gene_network.txt"
-whose machine leaning model is "Ensemble ADAGE 300", we will type:
-  python manage.py import_node_gene_network /path/of/node_gene_network.txt \
-"Ensemble ADAGE 300" "High-weight genes"
+For example, to import the data lines in an input file
+"signature_gene_network.txt" whose machine leaning model is
+"Ensemble ADAGE 300", we will type:
+  python manage.py import_signature_gene_network \
+/path/of/signature_gene_network.txt "Ensemble ADAGE 300" "High-weight genes"
 
 IMPORTANT:
 Before running this command, please:
@@ -37,7 +39,7 @@ from __future__ import print_function
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from genes.models import Gene
-from analyze.models import MLModel, Node, Participation, ParticipationType
+from analyze.models import MLModel, Signature, Participation, ParticipationType
 
 import logging
 logger = logging.getLogger(__name__)
@@ -45,29 +47,29 @@ logger.addHandler(logging.NullHandler())
 
 
 class Command(BaseCommand):
-    help = ("Imports node-gene network data into Participation table in the "
-            "database.")
+    help = ("Imports signature-gene network data into Participation table in "
+            "the database.")
 
     def add_arguments(self, parser):
-        parser.add_argument('node_gene_network_file', type=file)
+        parser.add_argument('signature_gene_network_file', type=file)
         parser.add_argument('ml_model_name', type=str)
         parser.add_argument('participation_type_name', type=str)
 
     def handle(self, **options):
         try:
-            import_network(options['node_gene_network_file'],
+            import_network(options['signature_gene_network_file'],
                            options['ml_model_name'],
                            options['participation_type_name'])
             self.stdout.write(self.style.NOTICE(
-                "Node-gene network data imported successfully"))
+                "Signature-gene network data imported successfully"))
         except Exception as e:
             raise CommandError(
-                "Failed to import Node-gene network data: %s" % e)
+                "Failed to import signature-gene network data: %s" % e)
 
 
 def import_network(file_handle, ml_model_name, participation_type_name):
     """
-    This function tries to import node-gene network data in the database.
+    This function tries to import signature-gene network data in the database.
     It first validates input ml_model_name, then reads each valid data
     line in the input file into the database.  The whole reading/importing
     process is enclosed by a transaction context manager so that any
@@ -102,25 +104,26 @@ def check_and_import(file_handle, ml_model, participation_type):
     """Read valid data lines into the database.  An exception will be
     raised if any errors are detected in file_handle.
     """
-    nodes_in_file = set()
+    signatures_in_file = set()
     for line_index, line in enumerate(file_handle):
         tokens = line.rstrip("\t\r\n").split("\t")
         # Skip a line if it is blank or has only one field.
         if len(tokens) < 2:
             continue
 
-        node_name = tokens[0]
+        signature_name = tokens[0]
         gene_names = tokens[1:]
-        # Raise exception if the node name is duplicate in the file.
-        if node_name in nodes_in_file:
-            raise Exception("Input file line #%s: %s is a duplicate node in "
-                            "the file" % (line_index + 1, node_name))
+        # Raise exception if the signature name is duplicate in the file.
+        if signature_name in signatures_in_file:
+            raise Exception("Input file line #%s: %s is a duplicate signature "
+                            "in the file" % (line_index + 1, signature_name))
 
         try:
-            node = Node.objects.get(name=node_name, mlmodel=ml_model)
-        except Node.DoesNotExist:
-            raise Exception("Input file line #%s: Node name %s not found in "
-                            "database" % (line_index + 1, node_name))
+            signature = Signature.objects.get(name=signature_name,
+                                              mlmodel=ml_model)
+        except Signature.DoesNotExist:
+            raise Exception("Input file line #%s: Signature name %s not found "
+                            "in database" % (line_index + 1, signature_name))
 
         records = []
         for sys_name in gene_names:
@@ -140,22 +143,22 @@ def check_and_import(file_handle, ml_model, participation_type):
                                "database", line_index + 1, sys_name)
                 continue
 
-            # Raise an exception if the combination of (node, gene,
+            # Raise an exception if the combination of (signature, gene,
             # participation_type) already exists in Participation table.
             # Instead of relying on the IntegrityError exception
             # implicitly, we raise an explicit exception that includes the
             # input file's line number where the error is detected, and
-            # node name, gene name, and participation_type name involved.
+            # signature name, gene name, and participation_type name involved.
             if Participation.objects.filter(
-                    node=node, gene=gene,
+                    signature=signature, gene=gene,
                     participation_type=participation_type).exists():
                 raise Exception("Input file line #%s: (%s, %s, %s) already "
                                 "exists in Participation table." %
-                                (line_index + 1, node_name, sys_name,
+                                (line_index + 1, signature_name, sys_name,
                                  participation_type.name))
             else:
                 records.append(
-                    Participation(node=node,
+                    Participation(signature=signature,
                                   gene=gene,
                                   participation_type=participation_type)
                 )
@@ -163,6 +166,6 @@ def check_and_import(file_handle, ml_model, participation_type):
         # Create database records in bulk.
         Participation.objects.bulk_create(records)
 
-        # Save this node name so that we can check node duplicate(s) in
-        # the file later.
-        nodes_in_file.add(node_name)
+        # Save this signature name so that we can check signature
+        # duplicate(s) in the file later.
+        signatures_in_file.add(signature_name)

--- a/adage/analyze/management/commands/import_signature_gene_network.py
+++ b/adage/analyze/management/commands/import_signature_gene_network.py
@@ -1,7 +1,7 @@
 """
 This management command will read an input signature-gene network file and
 populate the "Participation" table in the database.  A valid input file
-must be tab-delimited and each line must start with a valid signaure name,
+must be tab-delimited and each line must start with a valid signature name,
 followed by systematic names of genes that are related to this signature.
 
 Here is an example input file:

--- a/adage/analyze/migrations/0009_auto_20170503_1700.py
+++ b/adage/analyze/migrations/0009_auto_20170503_1700.py
@@ -10,10 +10,6 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def create_participation_type_if_nonexistent(apps, schema_editor):
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [

--- a/adage/analyze/migrations/0009_auto_20170503_1700.py
+++ b/adage/analyze/migrations/0009_auto_20170503_1700.py
@@ -1,28 +1,17 @@
 # -*- coding: utf-8 -*-
+
+"""This migration file used to generate a default participation type and
+set all Participation records to the default type.  These operations
+have been moved to fabfile/adage_server.py now.
+"""
+
 from __future__ import unicode_literals
 
 from django.db import migrations
 
-from analyze.models import Participation, ParticipationType
-
 
 def create_participation_type_if_nonexistent(apps, schema_editor):
-    """
-    Function that creates the ParticipationType "High weight genes"
-    and assigns it to all the existing Participation objects if
-    no ParticipationTypes were previously in the database.
-    """
-    if not ParticipationType.objects.exists():
-        new_participation_type = ParticipationType.objects.create(
-            name="High-weight genes", description="High-weight genes are "
-            "those that most strongly influence the signature's activity, "
-            "and we have found that they often reveal the underlying process "
-            "or processes captured by the signature."
-        )
-
-        for participation_obj in Participation.objects.all():
-            participation_obj.participation_type = new_participation_type
-            participation_obj.save()
+    pass
 
 
 class Migration(migrations.Migration):
@@ -31,6 +20,4 @@ class Migration(migrations.Migration):
         ('analyze', '0008_auto_20170501_1359'),
     ]
 
-    operations = [
-        migrations.RunPython(create_participation_type_if_nonexistent),
-    ]
+    operations = []

--- a/adage/analyze/migrations/0013_auto_20171108_1152.py
+++ b/adage/analyze/migrations/0013_auto_20171108_1152.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analyze', '0012_mlmodel_g2g_edge_cutoff'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name='Node',
+            new_name='Signature',
+        ),
+        migrations.RenameField(
+            model_name='activity',
+            old_name='node',
+            new_name='signature',
+        ),
+        migrations.RenameField(
+            model_name='participation',
+            old_name='node',
+            new_name='signature',
+        ),
+        migrations.AlterUniqueTogether(
+            name='activity',
+            unique_together=set([('sample', 'signature')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='participation',
+            unique_together=set([('signature', 'gene', 'participation_type')]),
+        ),
+    ]

--- a/fabfile/adage_server.py
+++ b/fabfile/adage_server.py
@@ -187,6 +187,16 @@ def import_data_and_index():
         '--tax_id_col=1 --discontinued_id_col=3 --discontinued_symbol_col=4') %
         CONFIG['data']['gene_history_file'])
 
+    # Create participation type
+    participation_type_name = "High-weight genes"
+    participation_type_desc = (
+        "High-weight genes are those that most strongly influence the "
+        "signature's activity, and we have found that they often reveal the "
+        "underlying process or processes captured by the signature."
+    )
+    run('python manage.py create_or_update_participation_type "%s" "%s"'
+        % (participation_type_name, participation_type_desc))
+
     mlmodel_basic = {
         "title": "Ensemble ADAGE 300",
         "cutoff": 0.4
@@ -211,14 +221,12 @@ def import_data_and_index():
         # Import activity data
         run('python manage.py import_activity "%s" "%s"' %
             (CONFIG['data']['activity_file'], mlmodel["title"]))
-        # Import participation data.  Note that the ParticipationType
-        # "High-weight genes" has been created in:
-        # migrations/0009_auto_20170503_1700.py
-        run('python manage.py import_signature_gene_network "%s" "%s" '
-            '"High-weight genes"' % (
-                CONFIG['data']['signature_gene_network_file'],
-                mlmodel["title"]
-            ))
+        # Import participation data
+        run('python manage.py import_signature_gene_network "%s" "%s" "%s"' % (
+            CONFIG['data']['signature_gene_network_file'],
+            mlmodel["title"],
+            participation_type_name
+        ))
         # Import gene-gene network data
         run('python manage.py import_gene_network "%s" "%s"' %
             (gene_gene_network_file, mlmodel["title"]))

--- a/interface/src/app/analyze/analysis/analysis.js
+++ b/interface/src/app/analyze/analysis/analysis.js
@@ -102,7 +102,7 @@ function AnalysisCtrl($scope, $log, $q, $state, $stateParams, SampleBin) {
         'transform': [
           {
             'type': 'aggregate',
-            'groupby': ['node'],
+            'groupby': ['signature'],
             'summarize': [{'field': 'normval', 'ops': ['min']}]
           }
         ]
@@ -115,8 +115,8 @@ function AnalysisCtrl($scope, $log, $q, $state, $stateParams, SampleBin) {
           {
             'type': 'lookup',
             'on': 'signature_summary',
-            'onKey': 'node',
-            'keys': ['node'],
+            'onKey': 'signature',
+            'keys': ['signature'],
             'as': ['signature_summary']
           }, {
             'type': 'formula',
@@ -132,7 +132,7 @@ function AnalysisCtrl($scope, $log, $q, $state, $stateParams, SampleBin) {
             'type': 'lookup',
             'on': 'signatureOrder',
             'onKey': 'data',
-            'keys': ['node'],
+            'keys': ['signature'],
             'as': ['signature_order']
           }
         ]
@@ -203,7 +203,7 @@ function AnalysisCtrl($scope, $log, $q, $state, $stateParams, SampleBin) {
         'properties': {
           'enter': {
             // TODO dynamic layout: compute these constants also (see above)
-            'text': {'value': 'node'},
+            'text': {'value': 'signature'},
             'x': {'value': 1200},
             'y': {'value': 220},
             'fontWeight': {'value': 'bold'},

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -15,7 +15,7 @@ angular.module('adage.analyze.sampleBin', [
 .factory('SignatureSet', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
     return $resource(
-      ApiBasePath + 'node/post_multiple/',
+      ApiBasePath + 'signature/post_multiple/',
       {},
       {post: {
         method: 'POST',
@@ -190,15 +190,15 @@ MathFuncts, errGen) {
       //      and constructing a `signatureObject` for each. [outer .map()]
       var retval = firstSampleSignatures.map(function(val, index) {
         var signatureObject = {
-          'id': val.node,
+          'id': val.signature,
           'activity': this.heatmapData.samples.map(
             // (2b) the array of activity for each signature is built by
             //      plucking the activity `.value` for each sample within the
             //      `index`th signature from the `activityCache` [inner .map()]
             function(sampleId) {
               var cachedActivity = this.activityCache.get(sampleId);
-              if (cachedActivity[index].node !== val.node) {
-                // ensure we're pulling out the right node (aka signature)
+              if (cachedActivity[index].signature !== val.signature) {
+                // ensure we're pulling out the right signature (aka signature)
                 $log.error(
                   'getSignatureObjects: signature IDs do not match. First ' +
                   ' sample = ', val, ', but sample ' + sampleId + ' =',
@@ -325,7 +325,7 @@ MathFuncts, errGen) {
         .linkage('avg')
         .posKey('activity')
         .data(this.getSampleObjects());
-      this.heatmapData.samples = sampleClust.orderedNodes().map(
+      this.heatmapData.samples = sampleClust.orderedSignatures().map(
         this._getIDs);
     },
     clusterSignatures: function() {
@@ -349,7 +349,7 @@ MathFuncts, errGen) {
           .data(cbSampleBin.getSignatureObjects());
         // update the heatmap
         cbSampleBin.heatmapData.signatureOrder =
-          signatureClust.orderedNodes().map(cbSampleBin._getIDs);
+          signatureClust.orderedSignatures().map(cbSampleBin._getIDs);
       });
     },
 
@@ -393,7 +393,7 @@ MathFuncts, errGen) {
             if (cbSampleBin.heatmapData.signatureOrder.length === 0) {
               cbSampleBin.heatmapData.signatureOrder = sampleActivity.map(
                 function(val) {
-                  return val.node;
+                  return val.signature;
                 }
               );
             }
@@ -422,7 +422,7 @@ MathFuncts, errGen) {
           var p = Activity.get({
             'mlmodel': mlmodel,
             'sample': samples[i],
-            'order_by': 'node'
+            'order_by': 'signature'
           }).$promise;
           activityPromises.push(p);
           p.then(loadCache).catch(this.logError);
@@ -475,7 +475,7 @@ MathFuncts, errGen) {
       //      for the first sample in our volcano plot
       var firstSampleSignatures = this.activityCache.get(sg['base-group'][0])
         .map(function(val) {
-          return val.node;  // extract just the signature IDs
+          return val.signature;  // extract just the signature IDs
         }
       );
       // (1b) now obtain (and cache) a name for each signature id
@@ -495,8 +495,8 @@ MathFuncts, errGen) {
               //      `index`th signature from the `activityCache`
               //      [inner .map()]
               var cachedActivity = cbSampleBin.activityCache.get(sampleId);
-              if (cachedActivity[index].node !== signatureId) {
-                // ensure we're pulling out the right node
+              if (cachedActivity[index].signature !== signatureId) {
+                // ensure we're pulling out the right signature
                 $log.error(
                   'mapSignaturesToSignatureInfo: signature IDs do not match.' +
                   ' First sample = ' + signatureId + ', but sample ' +

--- a/interface/src/app/analyze/analysis/sampleBin.js
+++ b/interface/src/app/analyze/analysis/sampleBin.js
@@ -198,7 +198,7 @@ MathFuncts, errGen) {
             function(sampleId) {
               var cachedActivity = this.activityCache.get(sampleId);
               if (cachedActivity[index].signature !== val.signature) {
-                // ensure we're pulling out the right signature (aka signature)
+                // ensure we're pulling out the right signature
                 $log.error(
                   'getSignatureObjects: signature IDs do not match. First ' +
                   ' sample = ', val, ', but sample ' + sampleId + ' =',
@@ -325,7 +325,7 @@ MathFuncts, errGen) {
         .linkage('avg')
         .posKey('activity')
         .data(this.getSampleObjects());
-      this.heatmapData.samples = sampleClust.orderedSignatures().map(
+      this.heatmapData.samples = sampleClust.orderedNodes().map(
         this._getIDs);
     },
     clusterSignatures: function() {
@@ -349,7 +349,7 @@ MathFuncts, errGen) {
           .data(cbSampleBin.getSignatureObjects());
         // update the heatmap
         cbSampleBin.heatmapData.signatureOrder =
-          signatureClust.orderedSignatures().map(cbSampleBin._getIDs);
+          signatureClust.orderedNodes().map(cbSampleBin._getIDs);
       });
     },
 

--- a/interface/src/app/help/help.tpl.html
+++ b/interface/src/app/help/help.tpl.html
@@ -27,7 +27,7 @@
     as the authors chose. Experiments vary in the number of samples they
     contain. Samples may be from different conditions or replicates. The
     annotations that accompany each experiment can help interpret the samples
-    and node activities within each experiment.
+    and signature activities within each experiment.
   </div>
   <br>
 
@@ -88,12 +88,12 @@
   <div class="lead" id="High Weight Gene">
     <h3><u>High Weight Gene</u></h3>
     A high weight gene in a signature is a genes whose weight is more than 2.5
-    standard deviations away from the mean weight of genes in that node.
-    Because the weight vectors of nodes have different distributions, different
-    nodes have different numbers of high weight genes. High weight genes are
-    used to characterize a node because their expression levels have the
-    largest influence on the activity of the node. A signature is composed of
-    high weight genes on one side of a node.
+    standard deviations away from the mean weight of genes in that signature.
+    Because the weight vectors of signatures have different distributions,
+    different signatures have different numbers of high weight genes. High
+    weight genes are used to characterize a signature because their expression
+    levels have the largest influence on the activity of the signature. A
+    signature is composed of high weight genes on one side of a node.
   </div>
   <br>
 

--- a/interface/src/app/help/help.tpl.html
+++ b/interface/src/app/help/help.tpl.html
@@ -87,13 +87,13 @@
 
   <div class="lead" id="High Weight Gene">
     <h3><u>High Weight Gene</u></h3>
-    A high weight gene in a signature is a genes whose weight is more than 2.5
-    standard deviations away from the mean weight of genes in that signature.
-    Because the weight vectors of signatures have different distributions,
-    different signatures have different numbers of high weight genes. High
-    weight genes are used to characterize a signature because their expression
-    levels have the largest influence on the activity of the signature. A
-    signature is composed of high weight genes on one side of a node.
+    The ADAGE model is made up of features (also known as nodes). For each
+    feature, every gene has a positive or negative weight. A signature is
+    composed of the genes on one side (positive or negative) of a feature.
+    The genes that are termed high weight are those that are 2.5 or more
+    standard deviations from the mean gene weight. These high weight genes
+    are used to characterize each signature because their expression levels
+    have the largest influence on the activity of the signature.
   </div>
   <br>
 

--- a/interface/src/app/sample_annotation/annotation.js
+++ b/interface/src/app/sample_annotation/annotation.js
@@ -61,7 +61,7 @@ angular.module('adage.sampleAnnotation', [
         self.activityDigits = ActivityDigits;
         var signatureID = $stateParams.signature;
         Activity.get(
-          {'node': signatureID, 'sample__in': samplesInUrl},
+          {'signature': signatureID, 'sample__in': samplesInUrl},
           function success(response) {
             var validSamples = [];
             response.objects.forEach(function(element) {

--- a/interface/src/app/signature/resources.js
+++ b/interface/src/app/signature/resources.js
@@ -7,7 +7,7 @@ angular.module('adage.signature.resources', [
 
 .factory('Signature', ['$resource', 'ApiBasePath',
   function($resource, ApiBasePath) {
-    return $resource(ApiBasePath + 'node/:id');
+    return $resource(ApiBasePath + 'signature/:id');
   }
 ])
 

--- a/interface/src/app/signature/signature.js
+++ b/interface/src/app/signature/signature.js
@@ -84,7 +84,7 @@ angular.module('adage.signature', [
         $scope.$watch('selectedParticipationType', function() {
           if ($scope.selectedParticipationType) {
             Participation.get(
-              {'node': $scope.signatureId, 'limit': 0,
+              {'signature': $scope.signatureId, 'limit': 0,
                 'participation_type': $scope.selectedParticipationType.id},
               function success(response) {
                 $scope.genes = [];
@@ -219,7 +219,7 @@ angular.module('adage.signature', [
 
         // Get activities that are related to the current signature:
         var activityPromise = Activity.get(
-          {node: $scope.signatureId, limit: 0}
+          {signature: $scope.signatureId, limit: 0}
         ).$promise;
 
         // Function that will be called to handle experiment data
@@ -288,8 +288,9 @@ angular.module('adage.signature', [
               sampleID = response.objects[i].sample;
               $scope.activities[sampleID] = response.objects[i].value;
             }
-            return SignatureExperiment.get({node: $scope.signatureId, limit: 0})
-              .$promise;
+            return SignatureExperiment.get(
+              {signature: $scope.signatureId, limit: 0}
+            ).$promise;
           },
           function error(response) {
             var errMessage = errGen('Failed to get activities', response);

--- a/interface/src/app/signature/signature.spec.js
+++ b/interface/src/app/signature/signature.spec.js
@@ -58,13 +58,14 @@ describe('<participatory-genes> directive', function() {
     expect(elementScope).toBeDefined();
 
     parentScope.selectedParticipationType = {
-      'description': 'Genes in this node are high-weight',
+      'description': 'Genes in this signature are high-weight',
       'id': 1, 'name': 'High weight genes',
       'resource_uri': '/api/v0/participationtype/1/'
     };
 
-    var uri = '/api/v0/participation?limit=0&node=' + parentScope.signatureId +
-        '&participation_type=' + parentScope.selectedParticipationType.id;
+    var uri = '/api/v0/participation?limit=0&signature=' +
+        parentScope.signatureId + '&participation_type=' +
+        parentScope.selectedParticipationType.id;
 
     $httpBackend.expectGET(uri).respond({objects: mockGenes});
 
@@ -132,8 +133,9 @@ describe('<high-range-exp> directive', function() {
       ' top-exp="{{topExp}}"></high-range-exp>';
 
     element = $compile(testHTML)(parentScope);
-    activityUri = '/api/v0/activity?limit=0&node=' + parentScope.signatureID;
-    experimentUri = '/api/v0/experiment?limit=0&node=' +
+    activityUri = '/api/v0/activity?limit=0&signature=' +
+      parentScope.signatureID;
+    experimentUri = '/api/v0/experiment?limit=0&signature=' +
       parentScope.signatureID;
 
     mockExperiment = [{
@@ -176,27 +178,27 @@ describe('<high-range-exp> directive', function() {
   it('should get the appropriate activity values', function() {
     // Mocked activity response data:
     var mockActivity = [
-      {id: 1, node: 123, sample: 1001, value: 0.0854334209211516},
-      {id: 2, node: 123, sample: 1002, value: 0.0689115612702348},
-      {id: 3, node: 123, sample: 1003, value: 0.0702073433150119},
-      {id: 4, node: 123, sample: 1004, value: 0.0677049302827924},
-      {id: 5, node: 123, sample: 1005, value: 0.0712094377832054},
-      {id: 6, node: 123, sample: 1006, value: 0.0721038265557411},
-      {id: 7, node: 123, sample: 1007, value: 0.0715914344928831},
-      {id: 8, node: 123, sample: 1008, value: 0.0825894283807123},
-      {id: 9, node: 123, sample: 1009, value: 0.0836206569872482},
-      {id: 10, node: 123, sample: 1010, value: 0.0647705496729518},
-      {id: 11, node: 123, sample: 1011, value: 0.0658942367538415},
-      {id: 12, node: 123, sample: 1012, value: 0.0727115753936357},
-      {id: 13, node: 123, sample: 1013, value: 0.0790896289324697},
-      {id: 14, node: 123, sample: 1014, value: 0.0692046195604449},
-      {id: 15, node: 123, sample: 1015, value: 0.078560557941843},
-      {id: 16, node: 123, sample: 1016, value: 0.0743736434104904},
-      {id: 17, node: 123, sample: 1017, value: 0.07871175918013},
-      {id: 18, node: 123, sample: 1018, value: 0.0614160606502279},
-      {id: 19, node: 123, sample: 1019, value: 0.0661371872868119},
-      {id: 20, node: 123, sample: 1020, value: 0.0783672660119669},
-      {id: 21, node: 123, sample: 1021, value: 0.0769023791604038}
+      {id: 1, signature: 123, sample: 1001, value: 0.0854334209211516},
+      {id: 2, signature: 123, sample: 1002, value: 0.0689115612702348},
+      {id: 3, signature: 123, sample: 1003, value: 0.0702073433150119},
+      {id: 4, signature: 123, sample: 1004, value: 0.0677049302827924},
+      {id: 5, signature: 123, sample: 1005, value: 0.0712094377832054},
+      {id: 6, signature: 123, sample: 1006, value: 0.0721038265557411},
+      {id: 7, signature: 123, sample: 1007, value: 0.0715914344928831},
+      {id: 8, signature: 123, sample: 1008, value: 0.0825894283807123},
+      {id: 9, signature: 123, sample: 1009, value: 0.0836206569872482},
+      {id: 10, signature: 123, sample: 1010, value: 0.0647705496729518},
+      {id: 11, signature: 123, sample: 1011, value: 0.0658942367538415},
+      {id: 12, signature: 123, sample: 1012, value: 0.0727115753936357},
+      {id: 13, signature: 123, sample: 1013, value: 0.0790896289324697},
+      {id: 14, signature: 123, sample: 1014, value: 0.0692046195604449},
+      {id: 15, signature: 123, sample: 1015, value: 0.078560557941843},
+      {id: 16, signature: 123, sample: 1016, value: 0.0743736434104904},
+      {id: 17, signature: 123, sample: 1017, value: 0.07871175918013},
+      {id: 18, signature: 123, sample: 1018, value: 0.0614160606502279},
+      {id: 19, signature: 123, sample: 1019, value: 0.0661371872868119},
+      {id: 20, signature: 123, sample: 1020, value: 0.0783672660119669},
+      {id: 21, signature: 123, sample: 1021, value: 0.0769023791604038}
     ];
 
     $httpBackend.expectGET(activityUri).respond({objects: mockActivity});

--- a/interface/src/app/volcano-plot/volcano-plot.js
+++ b/interface/src/app/volcano-plot/volcano-plot.js
@@ -22,7 +22,7 @@ angular.module('adage.volcano-plot', [
     return {
       getGenesForSignaturesPromise: function(signatures) {
         var promise = Participation.get(
-          {'node__in': signatures.join(), 'limit': 0}
+          {'signature__in': signatures.join(), 'limit': 0}
         ).$promise.then(
           function success(value) {
             // when the data come back, condense the reponse into a flat list


### PR DESCRIPTION
This PR fixes issue #138. It affects both back end and front end files. 

After talking to Rene, I moved the functionalities in migration file `0009_auto_20170503_1700.py` to deployment in `fabfile/adage_server.py`. 

@mhuyck, please review **at least** the following front end files carefully to make sure that my revisions are correct:
```
interface/src/app/analyze/analysis/analysis.js
interface/src/app/analyze/analysis/sampleBin.js
interface/src/app/volcano-plot/volcano-plot.js
```

This file is also revised: `interface/src/app/help/help.tpl.html`, but I am not sure whether we should keep both "Node" and "Signature" sections. It is confusing to me.
