### PR TITLE
About Page: Add the new paragraph with BMC paper URL

### DIFF
--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -21,9 +21,7 @@
   The ADAGE server is open source. If you'd like to start your own instance of
   the ADAGE server, modify the source, or participate in development, please
   visit our
-  <a href="https://github.com/greenelab/adage-server">
-    GitHub repository
-  </a>.
+  <a href="https://github.com/greenelab/adage-server">GitHub repository</a>.
 </p>
 
 <p>

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -16,10 +16,10 @@
   types of machine learning models as well.
 </p>
 
-<!--
-<p>
+<p class="h4">
   If you use the server for any type of model, please cite the
-  [ADAGE Signature Analysis paper](Link TBD). Please also cite the paper that
-  reports the machine learning model that you use.
+  <a href="https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-017-1905-4">
+    ADAGE Signature Analysis paper
+  </a>. Please also cite the paper that reports the machine learning model that
+  you use.
 </p>
--->

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -2,7 +2,7 @@
   <h3>About ADAGE</h3>
 </div>
 
-<p class="h4">
+<p>
   The <strong>ADAGE</strong> (<strong>A</strong>nalysis using
   <strong>D</strong>enoising <strong>A</strong>utoencoders of
   <strong>G</strong>ene <strong>E</strong>xpression) web server allows users
@@ -13,13 +13,24 @@
   and
   <a href="http://biorxiv.org/content/early/2017/04/10/078659">eADAGE</a>;
   however, the server was designed to be general and can be used for other
-  types of machine learning models as well.
+  types of machine learning models as well. Signatures from PCA, ICA, NMF, and
+  other factorization methods can also be loaded into the server.
 </p>
 
-<p class="h4">
-  If you use the server for any type of model, please cite the
-  <a href="https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-017-1905-4">
-    ADAGE Signature Analysis paper
-  </a>. Please also cite the paper that reports the machine learning model that
-  you use.
+<p>
+  The ADAGE server is open source. If you'd like to start your own instance of
+  the ADAGE server, modify the source, or participate in development please
+  visit our
+  <a href="https://github.com/greenelab/adage-server">
+    GitHub repository
+  </a>.
+</p>
+
+<p>
+  If you would like to report issues with the server, please either
+  <a href="https://github.com/greenelab/adage-server/issues/new">
+    file an issue on GitHub
+  </a>
+  or drop the team an email via
+  <a href="mailto:greenescientist@gmail.com">Casey</a>.
 </p>

--- a/interface/src/app/about/about.tpl.html
+++ b/interface/src/app/about/about.tpl.html
@@ -19,7 +19,7 @@
 
 <p>
   The ADAGE server is open source. If you'd like to start your own instance of
-  the ADAGE server, modify the source, or participate in development please
+  the ADAGE server, modify the source, or participate in development, please
   visit our
   <a href="https://github.com/greenelab/adage-server">
     GitHub repository

--- a/interface/src/app/home/home.tpl.html
+++ b/interface/src/app/home/home.tpl.html
@@ -1,32 +1,47 @@
 <div class="page-header">
   <h3>ADAGE: Home</h3>
+  The ADAGE web server allows users to analyze signatures from certain types
+  of unsupervised machine learning models. If you use the ADAGE server,
+  please cite:
+  <br>
+  Tan J, Huyck M, Hu D, Zelaya RA, Hogan DA, Greene CS.
+  <strong>
+    <a href="https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-017-1905-4">
+      ADAGE signature analysis: differential expression analysis with
+      data-defined gene sets
+    </a>
+  </strong>
+  <em>BMC Bioinformatics. 2017.</em>
+  <br>
+  Please also cite the relevant paper for the model that you use, which is shown
+  after a model is selected.
 </div>
 
-<h3>Step 1: Choose a machine learning model</h3>
+<p class="lead">Step 1: Choose a machine learning model</p>
 <ml-model-selector selected-ml-model="ctrl.modelInfo"
                    on-change="ctrl.changeModel(value)">
 </ml-model-selector>
 
 <hr>
 <div ng-show="ctrl.modelInfo.title">
-  <h3>Step 2: Now that the model is set, you have three options:</h3>
+  <p class="lead">Step 2: Now that the model is set, you have three options:</h3>
     <ul>
       <li>
-        <h4><a ui-sref="analyze({mlmodel: modelInfo.id})">
+        <p><a ui-sref="analyze({mlmodel: modelInfo.id})">
             Explore assays and experiments
-        </a></h4>
+        </a></p>
       </li>
 
       <li>
-        <h4><a ui-sref="gene_search({mlmodel: modelInfo.id})">
+        <p><a ui-sref="gene_search({mlmodel: modelInfo.id})">
             Explore genes' model similarities
-        </a></h4>
+        </a></p>
       </li>
 
       <li>
-        <h4><a ui-sref="signature_search({mlmodel: modelInfo.id})">
+        <p><a ui-sref="signature_search({mlmodel: modelInfo.id})">
             Explore model signatures
-        </a></h4>
+        </a></p>
       </li>
     </ul>
 </div>

--- a/interface/src/app/home/home.tpl.html
+++ b/interface/src/app/home/home.tpl.html
@@ -11,7 +11,7 @@
       data-defined gene sets
     </a>
   </strong>
-  <em>BMC Bioinformatics. 2017.</em>
+  <em>BMC Bioinformatics.</em> 2017.
   <br>
   Please also cite the relevant paper for the model that you use, which is shown
   after a model is selected.

--- a/interface/src/app/home/home.tpl.html
+++ b/interface/src/app/home/home.tpl.html
@@ -17,14 +17,18 @@
   after a model is selected.
 </div>
 
-<p class="lead">Step 1: Choose a machine learning model</p>
+<p class="lead">
+  Step 1: Choose a machine learning model
+</p>
 <ml-model-selector selected-ml-model="ctrl.modelInfo"
                    on-change="ctrl.changeModel(value)">
 </ml-model-selector>
 
 <hr>
 <div ng-show="ctrl.modelInfo.title">
-  <p class="lead">Step 2: Now that the model is set, you have three options:</h3>
+  <p class="lead">
+    Step 2: Now that the model is set, you have three options:
+  </p>
     <ul>
       <li>
         <p><a ui-sref="analyze({mlmodel: modelInfo.id})">


### PR DESCRIPTION
This PR is addressing issues #163 and #314. See the demo page at:
http://165.123.67.202/#/about

@jaclyn-taroni proposed that the BMC paper's link be added onto the page of "Home" too. I agree that it will be more obvious, but it may be a little distracting. What do you think @cgreene? 