### PR TITLE
Remove Codeship config and update Django packages

### DIFF
--- a/adage/adage/config.py.template
+++ b/adage/adage/config.py.template
@@ -183,23 +183,6 @@ CI_CONFIG.update({
     }
 })
 
-# Codeship server deployment credentials and configuration
-CODESHIP_CONFIG = CI_CONFIG.copy()
-CODESHIP_CONFIG.update({
-    # see https://codeship.com/documentation/databases/postgresql/
-    'databases': {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            # database name and user cannot have upper case letters
-            'NAME': 'adageci',
-            'USER': '<configure>',
-            'PASSWORD': '<config-secret>',
-            'HOST': '127.0.0.1',
-            'PORT': '5434',  # v. 9.4
-        }
-    },
-})
-
 CIRCLECI_CONFIG = CI_CONFIG.copy()
 CIRCLECI_CONFIG.update({
     'databases': {

--- a/adage/adage/settings.py
+++ b/adage/adage/settings.py
@@ -19,11 +19,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # come from config.py, which is never checked into source control.
 # If we're running under CircleCI, we build a CONFIG on the fly using
 # `config.py.template`.
-if os.environ.get('CIRCLECI') == 'true':
+if os.environ.get('CIRCLECI', 'false'):
     with open(os.path.join(BASE_DIR, 'adage', 'config.py.template')) as f:
         exec f
     CONFIG = CIRCLECI_CONFIG
-elif os.environ.get('DOCKER_DEV') == 'true':
+elif os.environ.get('DOCKER_DEV', 'false'):
     with open(os.path.join(BASE_DIR, 'adage', 'config.py.template')) as f:
         exec f
     CONFIG = DOCKER_DEV

--- a/adage/adage/settings.py
+++ b/adage/adage/settings.py
@@ -19,11 +19,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # come from config.py, which is never checked into source control.
 # If we're running under CircleCI, we build a CONFIG on the fly using
 # `config.py.template`.
-if os.environ.get('CIRCLECI', 'false'):
+if os.environ.get('CIRCLECI', 'false') == 'true':
     with open(os.path.join(BASE_DIR, 'adage', 'config.py.template')) as f:
         exec f
     CONFIG = CIRCLECI_CONFIG
-elif os.environ.get('DOCKER_DEV', 'false'):
+elif os.environ.get('DOCKER_DEV', 'false') == 'true':
     with open(os.path.join(BASE_DIR, 'adage', 'config.py.template')) as f:
         exec f
     CONFIG = DOCKER_DEV

--- a/adage/adage/settings.py
+++ b/adage/adage/settings.py
@@ -16,15 +16,10 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Any deployment configuration settings (including all secrets)
-# come from config.py, which is never checked into source control. If we're
-# running under Codeship we build a CONFIG on the fly using config.py.template
-if os.environ.get('CODESHIP_SETTINGS') == 'YES':
-    with open(os.path.join(BASE_DIR, 'adage', 'config.py.template')) as f:
-        exec f
-    CONFIG = CODESHIP_CONFIG
-    CONFIG['databases']['default']['USER'] = os.environ.get('PG_USER')
-    CONFIG['databases']['default']['PASSWORD'] = os.environ.get('PG_PASSWORD')
-elif os.environ.get('CIRCLECI') == 'true':
+# come from config.py, which is never checked into source control.
+# If we're running under CircleCI, we build a CONFIG on the fly using
+# `config.py.template`.
+if os.environ.get('CIRCLECI') == 'true':
     with open(os.path.join(BASE_DIR, 'adage', 'config.py.template')) as f:
         exec f
     CONFIG = CIRCLECI_CONFIG

--- a/adage/requirements.txt
+++ b/adage/requirements.txt
@@ -1,9 +1,9 @@
 argparse==1.2.1
-Django==1.8.19
+Django==1.11.18
 django-fixtureless==1.4.3.3
-django-haystack==2.6.0
-django-tastypie==0.13.3
-elasticsearch==1.9.0
+django-haystack==2.8.1
+django-tastypie==0.14.2
+elasticsearch==2.4.1
 gunicorn==19.9.0
 psycopg2==2.7.3.1
 python-dateutil==2.5.0

--- a/adage/requirements.txt
+++ b/adage/requirements.txt
@@ -1,4 +1,3 @@
-argparse==1.2.1
 Django==1.11.18
 django-fixtureless==1.4.3.3
 django-haystack==2.8.1


### PR DESCRIPTION
This PR removes `Codeship` from Django settings, and updates a few Django packages.

These changes have been validated on my desktop and confirmed by CircleCI tests.